### PR TITLE
Add docs safety check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "pnpm run --filter @oligopoly/worker dev & pnpm run --filter @oligopoly/web dev & wait",
     "dev:worker": "pnpm run --filter @oligopoly/worker dev",
     "dev:web": "pnpm run --filter @oligopoly/web dev",
+    "docs:check": "./scripts/docs-safety-check.sh",
     "build": "pnpm run -r build",
     "typecheck": "tsc --build",
     "lint": "eslint .",

--- a/scripts/docs-safety-check.sh
+++ b/scripts/docs-safety-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+shopt -s nullglob globstar
+
+FILES=(./*.md ./docs/**/*.md)
+
+if ((${#FILES[@]} == 0)); then
+  echo "✓ No findings"
+  exit 0
+fi
+
+HAS_FINDINGS=0
+
+check_pattern() {
+  local label="$1"
+  local pattern="$2"
+  local case_flag="${3:-}"
+  local -a rg_args=(--line-number --with-filename --pcre2 "$pattern")
+
+  if [[ -n "$case_flag" ]]; then
+    rg_args+=("$case_flag")
+  fi
+
+  if MATCHES="$(rg "${rg_args[@]}" "${FILES[@]}")"; then
+    HAS_FINDINGS=1
+    echo "Found ${label}:"
+    echo "${MATCHES}"
+    echo
+  fi
+}
+
+check_pattern "blocked secret keyword(s)" "AUTH_SECRET|SESSION_SECRET|PRIVATE_KEY|smtp://|sendgrid|mailgun|postmark" "-i"
+check_pattern "possible secret assignment(s)" "[A-Z_]+=.*[a-zA-Z0-9+/]{20,}"
+check_pattern "hosted-only deployment reference(s)" "fly\\.io|railway|render\\.com" "-i"
+
+if ((HAS_FINDINGS)); then
+  exit 1
+fi
+
+echo "✓ No findings"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `scripts/docs-safety-check.sh` to scan public markdown docs for blocked secret-like and hosted-only patterns
- fail with offending file and line details when findings are present
- add root `docs:check` script in `package.json`

## Testing
- `./scripts/docs-safety-check.sh`
- `pnpm run docs:check`

## Issue
- closes #16
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f246f8bf-0ed5-4a38-bb20-bf4b677c6ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f246f8bf-0ed5-4a38-bb20-bf4b677c6ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

