### PR TITLE
Fix Vitest workspace resolution for monorepo packages

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,19 +1,41 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineWorkspace } from "vitest/config";
+
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+
+const workspaceAliases = {
+  "@oligopoly/shared": path.resolve(repoRoot, "packages/shared/src/index.ts"),
+  "@oligopoly/validation": path.resolve(
+    repoRoot,
+    "packages/validation/src/index.ts",
+  ),
+  "@oligopoly/worker": path.resolve(repoRoot, "packages/worker/src/index.ts"),
+};
 
 export default defineWorkspace([
   {
+    resolve: {
+      alias: workspaceAliases,
+    },
     test: {
       name: "unit",
       include: ["tests/unit/**/*.test.ts"],
     },
   },
   {
+    resolve: {
+      alias: workspaceAliases,
+    },
     test: {
       name: "integration",
       include: ["tests/integration/**/*.test.ts"],
     },
   },
   {
+    resolve: {
+      alias: workspaceAliases,
+    },
     test: {
       name: "e2e",
       include: ["tests/e2e/**/*.test.ts"],


### PR DESCRIPTION
### Motivation

- Vitest on a clean checkout attempted to resolve `@oligopoly/shared` and `@oligopoly/validation` via package `exports` that point at `dist/*`, which do not exist until packages are built, causing unit tests to fail.
- Tests and contributor workflows must run without requiring prebuilt artifacts, so the workspace test runner should resolve imports to source entrypoints.

### Description

- Add a `resolve.alias` map to `vitest.workspace.ts` that points `@oligopoly/shared`, `@oligopoly/validation`, and `@oligopoly/worker` to their `packages/*/src/index.ts` source files.
- Compute absolute paths for aliases using `import.meta.url` + `path.resolve` to ensure deterministic resolution across projects.
- Apply the alias resolution to the unit, integration, and e2e workspace projects so all test suites import source code directly.

### Testing

- Ran `pnpm run test:unit` which now passes (all unit tests green).
- Ran `pnpm run test:integration` which now passes (all integration tests green).
- Ran `pnpm exec biome check vitest.workspace.ts` which passes (import order lint fix applied to the workspace file).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c60ef5848331b61e87a3c95d6794)