### PR TITLE
feat(shared): add serializeProfileForAudience utility

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,20 @@ export {
   UpdateUserSettingsInputSchema,
   VisibilitySettingSchema,
 } from "@oligopoly/validation";
+export type {
+  AchievementUnlock,
+  CareerStats,
+  FullUserProfile,
+  GameResult,
+  NotificationPrefs,
+  OnlineStatus,
+  PrivateUserProfile,
+  PublicUserProfile,
+  RecentGameSummary,
+  ViewerContext,
+  ViewerUserProfile,
+} from "./profile/types.js";
+export { serializeProfileForAudience } from "./profile/serializeProfileForAudience.js";
 
 export const DEFAULT_PROFILE_VISIBILITY = {
   rank: "public" as const,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export {
   UpdateUserSettingsInputSchema,
   VisibilitySettingSchema,
 } from "@oligopoly/validation";
+export { serializeProfileForAudience } from "./profile/serializeProfileForAudience.js";
 export type {
   AchievementUnlock,
   CareerStats,
@@ -24,7 +25,6 @@ export type {
   ViewerContext,
   ViewerUserProfile,
 } from "./profile/types.js";
-export { serializeProfileForAudience } from "./profile/serializeProfileForAudience.js";
 
 export const DEFAULT_PROFILE_VISIBILITY = {
   rank: "public" as const,

--- a/packages/shared/src/profile/serializeProfileForAudience.ts
+++ b/packages/shared/src/profile/serializeProfileForAudience.ts
@@ -1,4 +1,7 @@
-import type { ProfileVisibility, VisibilitySetting } from "@oligopoly/validation";
+import type {
+  ProfileVisibility,
+  VisibilitySetting,
+} from "@oligopoly/validation";
 import type {
   FullUserProfile,
   PrivateUserProfile,
@@ -14,7 +17,9 @@ function clonePublicFields(profile: FullUserProfile): PublicUserProfile {
     rankTier: profile.rankTier,
     rankTitle: profile.rankTitle,
     careerStats: profile.careerStats ? { ...profile.careerStats } : undefined,
-    achievements: profile.achievements?.map((achievement) => ({ ...achievement })),
+    achievements: profile.achievements?.map((achievement) => ({
+      ...achievement,
+    })),
     recentGames: profile.recentGames?.map((game) => ({ ...game })),
     onlineStatus: profile.onlineStatus,
     lastSeenAt: profile.lastSeenAt,
@@ -81,13 +86,19 @@ export function serializeProfileForAudience(
     };
   }
 
-  if (profile.achievements && isVisibleToAudience(visibility.achievements, audience)) {
+  if (
+    profile.achievements &&
+    isVisibleToAudience(visibility.achievements, audience)
+  ) {
     serialized.achievements = profile.achievements.map((achievement) => ({
       ...achievement,
     }));
   }
 
-  if (profile.recentGames && isVisibleToAudience(visibility.recentGames, audience)) {
+  if (
+    profile.recentGames &&
+    isVisibleToAudience(visibility.recentGames, audience)
+  ) {
     serialized.recentGames = profile.recentGames.map((game) => ({ ...game }));
   }
 

--- a/packages/shared/src/profile/serializeProfileForAudience.ts
+++ b/packages/shared/src/profile/serializeProfileForAudience.ts
@@ -1,0 +1,118 @@
+import type { ProfileVisibility, VisibilitySetting } from "@oligopoly/validation";
+import type {
+  FullUserProfile,
+  PrivateUserProfile,
+  PublicUserProfile,
+  ViewerUserProfile,
+} from "./types.js";
+
+function clonePublicFields(profile: FullUserProfile): PublicUserProfile {
+  return {
+    id: profile.id,
+    username: profile.username,
+    avatarUrl: profile.avatarUrl,
+    rankTier: profile.rankTier,
+    rankTitle: profile.rankTitle,
+    careerStats: profile.careerStats ? { ...profile.careerStats } : undefined,
+    achievements: profile.achievements?.map((achievement) => ({ ...achievement })),
+    recentGames: profile.recentGames?.map((game) => ({ ...game })),
+    onlineStatus: profile.onlineStatus,
+    lastSeenAt: profile.lastSeenAt,
+  };
+}
+
+function clonePrivateProfile(profile: FullUserProfile): PrivateUserProfile {
+  return {
+    ...clonePublicFields(profile),
+    viewerContext: { ...profile.viewerContext },
+    email: profile.email,
+    fullName: profile.fullName,
+    locale: profile.locale,
+    timezone: profile.timezone,
+    currency: profile.currency,
+    country: profile.country,
+    themePreference: profile.themePreference,
+    notificationPrefs: { ...profile.notificationPrefs },
+    profileVisibility: { ...profile.profileVisibility },
+    usernameLastChangedAt: profile.usernameLastChangedAt,
+  };
+}
+
+function isVisibleToAudience(
+  setting: VisibilitySetting,
+  audience: "public" | "viewer",
+): boolean {
+  if (audience === "public") {
+    return setting === "public";
+  }
+
+  return setting === "public" || setting === "authenticated";
+}
+
+export function serializeProfileForAudience(
+  profile: FullUserProfile,
+  audience: "public" | "viewer" | "owner",
+  visibility: ProfileVisibility,
+): PublicUserProfile | ViewerUserProfile | PrivateUserProfile {
+  if (audience === "owner") {
+    return clonePrivateProfile(profile);
+  }
+
+  const serialized: PublicUserProfile = {
+    id: profile.id,
+    username: profile.username,
+    avatarUrl: profile.avatarUrl,
+  };
+
+  if (isVisibleToAudience(visibility.rank, audience)) {
+    serialized.rankTier = profile.rankTier;
+    serialized.rankTitle = profile.rankTitle;
+  }
+
+  if (
+    profile.careerStats &&
+    isVisibleToAudience(visibility.careerStats, audience)
+  ) {
+    serialized.careerStats = {
+      ...profile.careerStats,
+      favoriteSector: isVisibleToAudience(visibility.favoriteSector, audience)
+        ? profile.careerStats.favoriteSector
+        : null,
+    };
+  }
+
+  if (profile.achievements && isVisibleToAudience(visibility.achievements, audience)) {
+    serialized.achievements = profile.achievements.map((achievement) => ({
+      ...achievement,
+    }));
+  }
+
+  if (profile.recentGames && isVisibleToAudience(visibility.recentGames, audience)) {
+    serialized.recentGames = profile.recentGames.map((game) => ({ ...game }));
+  }
+
+  if (
+    profile.onlineStatus &&
+    isVisibleToAudience(visibility.onlineStatus, audience)
+  ) {
+    serialized.onlineStatus = profile.onlineStatus;
+  }
+
+  if (
+    profile.lastSeenAt !== undefined &&
+    isVisibleToAudience(visibility.lastSeen, audience)
+  ) {
+    serialized.lastSeenAt = profile.lastSeenAt;
+  }
+
+  if (audience === "public") {
+    return serialized;
+  }
+
+  const viewerSerialized: ViewerUserProfile = {
+    ...serialized,
+    viewerContext: { ...profile.viewerContext },
+  };
+
+  return viewerSerialized;
+}

--- a/packages/shared/src/profile/types.ts
+++ b/packages/shared/src/profile/types.ts
@@ -1,0 +1,64 @@
+import type { ProfileVisibility } from "@oligopoly/validation";
+
+export type GameResult = "won" | "lost" | "drew" | "kicked";
+export type OnlineStatus = "online" | "offline";
+
+export interface CareerStats {
+  gamesPlayed: number;
+  wins: number;
+  winRate: number;
+  tradesCompleted: number;
+  auctionsWon: number;
+  favoriteSector: string | null;
+}
+
+export interface AchievementUnlock {
+  id: string;
+  unlockedAt: number;
+}
+
+export interface RecentGameSummary {
+  gameId: string;
+  result: GameResult;
+  endedAt: number;
+}
+
+export interface ViewerContext {
+  isSelf: boolean;
+  sharedActiveGame: boolean;
+  sharedSyndicate: boolean;
+}
+
+export type NotificationPrefs = Record<string, unknown>;
+
+export interface PublicUserProfile {
+  id: string;
+  username: string;
+  avatarUrl: string | null;
+  rankTier?: number;
+  rankTitle?: string;
+  careerStats?: CareerStats;
+  achievements?: AchievementUnlock[];
+  recentGames?: RecentGameSummary[];
+  onlineStatus?: OnlineStatus;
+  lastSeenAt?: number;
+}
+
+export interface ViewerUserProfile extends PublicUserProfile {
+  viewerContext: ViewerContext;
+}
+
+export interface PrivateUserProfile extends ViewerUserProfile {
+  email: string;
+  fullName: string | null;
+  locale: string;
+  timezone: string;
+  currency: string;
+  country: string | null;
+  themePreference: string;
+  notificationPrefs: NotificationPrefs;
+  profileVisibility: ProfileVisibility;
+  usernameLastChangedAt: number | null;
+}
+
+export type FullUserProfile = PrivateUserProfile;

--- a/tests/unit/shared.test.ts
+++ b/tests/unit/shared.test.ts
@@ -2,9 +2,9 @@ import {
   canCreateBindingContract,
   clampTrustworthiness,
   DEFAULT_PROFILE_VISIBILITY,
+  type FullUserProfile,
   serializeProfileForAudience,
   TRUSTWORTHINESS_DEFAULT,
-  type FullUserProfile,
 } from "@oligopoly/shared";
 import { describe, expect, it } from "vitest";
 

--- a/tests/unit/shared.test.ts
+++ b/tests/unit/shared.test.ts
@@ -2,7 +2,9 @@ import {
   canCreateBindingContract,
   clampTrustworthiness,
   DEFAULT_PROFILE_VISIBILITY,
+  serializeProfileForAudience,
   TRUSTWORTHINESS_DEFAULT,
+  type FullUserProfile,
 } from "@oligopoly/shared";
 import { describe, expect, it } from "vitest";
 
@@ -40,5 +42,167 @@ describe("defaults", () => {
   it("has correct default profile visibility", () => {
     expect(DEFAULT_PROFILE_VISIBILITY.rank).toBe("public");
     expect(DEFAULT_PROFILE_VISIBILITY.onlineStatus).toBe("authenticated");
+  });
+});
+
+const makeProfile = (): FullUserProfile => ({
+  id: "user-1",
+  username: "oligarch",
+  avatarUrl: "https://example.com/avatar.png",
+  rankTier: 4,
+  rankTitle: "Market Mogul",
+  careerStats: {
+    gamesPlayed: 120,
+    wins: 55,
+    winRate: 0.458,
+    tradesCompleted: 340,
+    auctionsWon: 87,
+    favoriteSector: "Energy",
+  },
+  achievements: [{ id: "first_steps", unlockedAt: 1700000000000 }],
+  recentGames: [
+    { gameId: "g-1", result: "won", endedAt: 1700000001000 },
+    { gameId: "g-2", result: "lost", endedAt: 1700000002000 },
+  ],
+  onlineStatus: "online",
+  lastSeenAt: 1700000003000,
+  viewerContext: {
+    isSelf: false,
+    sharedActiveGame: true,
+    sharedSyndicate: false,
+  },
+  email: "oligarch@example.com",
+  fullName: "Market Player",
+  locale: "en-US",
+  timezone: "UTC",
+  currency: "USD",
+  country: "US",
+  themePreference: "dark",
+  notificationPrefs: {
+    email: true,
+    push: false,
+  },
+  profileVisibility: {
+    rank: "public",
+    careerStats: "public",
+    achievements: "authenticated",
+    recentGames: "private",
+    onlineStatus: "authenticated",
+    lastSeen: "private",
+    favoriteSector: "private",
+  },
+  usernameLastChangedAt: 1699999999000,
+});
+
+describe("serializeProfileForAudience", () => {
+  it("public audience hides authenticated/private fields", () => {
+    const profile = makeProfile();
+
+    const serialized = serializeProfileForAudience(
+      profile,
+      "public",
+      profile.profileVisibility,
+    );
+
+    expect(serialized).toStrictEqual({
+      id: "user-1",
+      username: "oligarch",
+      avatarUrl: "https://example.com/avatar.png",
+      rankTier: 4,
+      rankTitle: "Market Mogul",
+      careerStats: {
+        gamesPlayed: 120,
+        wins: 55,
+        winRate: 0.458,
+        tradesCompleted: 340,
+        auctionsWon: 87,
+        favoriteSector: null,
+      },
+    });
+  });
+
+  it("viewer audience includes public/authenticated fields but not private fields", () => {
+    const profile = makeProfile();
+
+    const serialized = serializeProfileForAudience(
+      profile,
+      "viewer",
+      profile.profileVisibility,
+    );
+
+    expect(serialized).toStrictEqual({
+      id: "user-1",
+      username: "oligarch",
+      avatarUrl: "https://example.com/avatar.png",
+      rankTier: 4,
+      rankTitle: "Market Mogul",
+      careerStats: {
+        gamesPlayed: 120,
+        wins: 55,
+        winRate: 0.458,
+        tradesCompleted: 340,
+        auctionsWon: 87,
+        favoriteSector: null,
+      },
+      achievements: [{ id: "first_steps", unlockedAt: 1700000000000 }],
+      onlineStatus: "online",
+      viewerContext: {
+        isSelf: false,
+        sharedActiveGame: true,
+        sharedSyndicate: false,
+      },
+    });
+  });
+
+  it("owner audience always includes private profile fields", () => {
+    const profile = makeProfile();
+
+    const serialized = serializeProfileForAudience(
+      profile,
+      "owner",
+      profile.profileVisibility,
+    );
+
+    expect(serialized).toStrictEqual(profile);
+  });
+
+  it("always includes username and avatarUrl regardless of visibility settings", () => {
+    const profile = makeProfile();
+    const restrictiveVisibility = {
+      rank: "private",
+      careerStats: "private",
+      achievements: "private",
+      recentGames: "private",
+      onlineStatus: "private",
+      lastSeen: "private",
+      favoriteSector: "private",
+    } as const;
+
+    const publicSerialized = serializeProfileForAudience(
+      profile,
+      "public",
+      restrictiveVisibility,
+    );
+    const viewerSerialized = serializeProfileForAudience(
+      profile,
+      "viewer",
+      restrictiveVisibility,
+    );
+
+    expect(publicSerialized).toStrictEqual({
+      id: "user-1",
+      username: "oligarch",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+    expect(viewerSerialized).toStrictEqual({
+      id: "user-1",
+      username: "oligarch",
+      avatarUrl: "https://example.com/avatar.png",
+      viewerContext: {
+        isSelf: false,
+        sharedActiveGame: true,
+        sharedSyndicate: false,
+      },
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add shared profile model types in `@oligopoly/shared`
- implement `serializeProfileForAudience(profile, audience, visibility)` for `public`, `viewer`, and `owner` audiences
- export new profile types and serializer from `packages/shared/src/index.ts`
- add unit tests covering public/viewer/owner visibility behavior and always-present `username`/`avatarUrl`
- merged latest `origin/main` and resolved merge conflict in `tests/unit/shared.test.ts` by keeping both upstream engine tests and profile serialization tests

## Conflict classification
- `tests/unit/shared.test.ts`: **simple conflict** (additive imports + independent test blocks from both branches; no conflicting intent)
- No complicated/intent-level conflicts found

## Testing
- `pnpm exec biome check tests/unit/shared.test.ts packages/shared/src/index.ts` ✅
- `pnpm exec vitest run --project unit tests/unit/shared.test.ts` ✅ (56 tests)
- `pnpm run typecheck` ✅

## Issue
- Addresses #4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d04a902-1b32-4e40-935e-f09be015b25f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d04a902-1b32-4e40-935e-f09be015b25f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

