### PR TITLE
docs: require planning docs to be consulted and maintained

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,31 @@ pnpm run test:unit   # Vitest — unit tests
 pnpm run test:integration  # Vitest — integration tests
 pnpm run test:e2e    # Vitest — e2e tests
 ```
+
+## Planning docs as required implementation context
+
+The root planning/rules markdown files are **authoritative context** for feature work and must be actively used:
+
+- `oligopoly_technical_plan.md` — canonical technical architecture, contracts, and phased implementation plan.
+- `oligopoly_game_rules.md` — canonical gameplay behavior, lobby/game rules, and product semantics.
+- `oligopoly_dev_guide.md` — local development workflow and command-level execution guidance.
+
+### Required workflow for implementation tasks
+
+When implementing, reviewing, or refactoring gameplay/runtime behavior:
+
+1. Read relevant sections of `oligopoly_technical_plan.md` and `oligopoly_game_rules.md` before coding.
+2. Treat these docs as default source-of-truth unless a higher-priority instruction in the prompt explicitly overrides them.
+3. If code changes alter behavior/contracts described in those docs, update the impacted sections in the same change set (or explicitly document why no doc update is needed).
+4. Keep naming and terminology aligned with these docs (for example: lobby/admin/co-admin/syndicate/trustworthiness wording).
+5. For ambiguous requirements, prefer the stricter interpretation that preserves determinism, server authority, and schema-backed contracts.
+
+### PR/documentation quality gate
+
+Before finalizing a task, verify and note:
+
+- Which sections of `oligopoly_technical_plan.md` informed the implementation.
+- Which sections of `oligopoly_game_rules.md` were validated against behavior.
+- Whether either file required updates, and exactly what changed.
+
+If no updates were needed, state that explicitly in the final summary.


### PR DESCRIPTION
### Motivation

- Make the repository's root planning and rules documents explicit authoritative context so implementation work stays aligned with product and technical intent.
- Reduce drift between code and high-level design by forcing doc review and updates when behavior or contracts change.

### Description

- Updated `AGENTS.md` to add a new “Planning docs as required implementation context” section that names `oligopoly_technical_plan.md`, `oligopoly_game_rules.md`, and `oligopoly_dev_guide.md` as required references.
- Added a required implementation workflow that instructs engineers to read relevant sections of `oligopoly_technical_plan.md` and `oligopoly_game_rules.md` before coding and to prefer stricter, deterministic interpretations for ambiguous cases.
- Added a PR/documentation quality gate that requires specifying which sections of the planning docs informed the change and whether those docs were updated as part of the same change set.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73050d5ac833193f6abfec1008e1e)