### PR TITLE
feat: add leaderboard and calls token routes

### DIFF
--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -271,6 +271,39 @@ export type UpdateLobbySettingsInput = z.infer<
   typeof UpdateLobbySettingsInputSchema
 >;
 
+// ---------------------------------------------------------------------------
+// Leaderboard schemas
+// ---------------------------------------------------------------------------
+export const LeaderboardWinsEntrySchema = z.object({
+  userId: z.string(),
+  username: z.string(),
+  wins: z.number().int(),
+});
+export type LeaderboardWinsEntry = z.infer<typeof LeaderboardWinsEntrySchema>;
+
+export const LeaderboardCompletionsEntrySchema = z.object({
+  userId: z.string(),
+  username: z.string(),
+  completions: z.number().int(),
+});
+export type LeaderboardCompletionsEntry = z.infer<
+  typeof LeaderboardCompletionsEntrySchema
+>;
+
+export const LeaderboardWinsResponseSchema = z.object({
+  entries: z.array(LeaderboardWinsEntrySchema),
+});
+export type LeaderboardWinsResponse = z.infer<
+  typeof LeaderboardWinsResponseSchema
+>;
+
+export const LeaderboardCompletionsResponseSchema = z.object({
+  entries: z.array(LeaderboardCompletionsEntrySchema),
+});
+export type LeaderboardCompletionsResponse = z.infer<
+  typeof LeaderboardCompletionsResponseSchema
+>;
+
 export const LobbyErrorKeys = {
   NOT_FOUND: "lobby.not_found",
   FULL: "lobby.full",

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -274,17 +274,19 @@ export type UpdateLobbySettingsInput = z.infer<
 // ---------------------------------------------------------------------------
 // Leaderboard schemas
 // ---------------------------------------------------------------------------
-export const LeaderboardWinsEntrySchema = z.object({
+export const LeaderboardEntrySchema = z.object({
   userId: z.string(),
   username: z.string(),
-  wins: z.number().int(),
+});
+export type LeaderboardEntry = z.infer<typeof LeaderboardEntrySchema>;
+
+export const LeaderboardWinsEntrySchema = LeaderboardEntrySchema.extend({
+  wins: z.number().int().nonnegative(),
 });
 export type LeaderboardWinsEntry = z.infer<typeof LeaderboardWinsEntrySchema>;
 
-export const LeaderboardCompletionsEntrySchema = z.object({
-  userId: z.string(),
-  username: z.string(),
-  completions: z.number().int(),
+export const LeaderboardCompletionsEntrySchema = LeaderboardEntrySchema.extend({
+  completions: z.number().int().nonnegative(),
 });
 export type LeaderboardCompletionsEntry = z.infer<
   typeof LeaderboardCompletionsEntrySchema
@@ -303,6 +305,28 @@ export const LeaderboardCompletionsResponseSchema = z.object({
 export type LeaderboardCompletionsResponse = z.infer<
   typeof LeaderboardCompletionsResponseSchema
 >;
+
+export const LeaderboardErrorKeys = {
+  INVALID_DATA: "leaderboard.invalid_data",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Calls schemas and error keys
+// ---------------------------------------------------------------------------
+export const CallsSessionTokenResponseSchema = z.object({
+  sessionId: z.string(),
+  sessionToken: z.string(),
+});
+export type CallsSessionTokenResponse = z.infer<
+  typeof CallsSessionTokenResponseSchema
+>;
+
+export const CallsErrorKeys = {
+  AUTH_REQUIRED: "calls.auth_required",
+  NOT_CONFIGURED: "calls.not_configured",
+  TOKEN_FAILED: "calls.token_failed",
+  UPSTREAM_INVALID: "calls.upstream_invalid",
+} as const;
 
 export const LobbyErrorKeys = {
   NOT_FOUND: "lobby.not_found",

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -3,7 +3,9 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { banCacheMiddleware } from "./middleware/banCache";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
+import { callsRoutes } from "./routes/calls";
 import { gameRoutes } from "./routes/games";
+import { leaderboardRoutes } from "./routes/leaderboard";
 import { lobbyRoutes } from "./routes/lobbies";
 import { userRoutes } from "./routes/users";
 
@@ -11,6 +13,8 @@ type Bindings = {
   ALLOWED_ORIGINS?: string;
   DB?: D1Database;
   KV?: KVNamespace;
+  CF_CALLS_APP_ID?: string;
+  CF_CALLS_APP_SECRET?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -59,6 +63,8 @@ app.all("/api/auth/*", (c) => {
 
 app.route("/api/games", gameRoutes);
 app.route("/api/users", userRoutes);
+app.route("/api/leaderboard", leaderboardRoutes);
+app.route("/api/calls", callsRoutes);
 
 app.notFound((c) => {
   return c.json({ error: "Not found" }, 404);

--- a/packages/worker/src/routes/calls.ts
+++ b/packages/worker/src/routes/calls.ts
@@ -1,3 +1,7 @@
+import {
+  CallsErrorKeys,
+  CallsSessionTokenResponseSchema,
+} from "@oligopoly/validation";
 import { Hono } from "hono";
 
 type Bindings = {
@@ -18,35 +22,48 @@ const getSubject = (c: {
 callsRoutes.post("/token", async (c) => {
   const subject = getSubject(c);
   if (!subject) {
-    return c.json({ error: "calls.auth_required" }, 401);
+    return c.json({ error: CallsErrorKeys.AUTH_REQUIRED }, 401);
   }
 
   const appId = c.env?.CF_CALLS_APP_ID;
   const appSecret = c.env?.CF_CALLS_APP_SECRET;
 
   if (!appId || !appSecret) {
-    return c.json({ error: "calls_not_configured" }, 501);
+    return c.json({ error: CallsErrorKeys.NOT_CONFIGURED }, 501);
   }
 
-  const response = await fetch(
-    `https://rtc.live.cloudflare.com/v1/apps/${appId}/sessions/new`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${appSecret}`,
-        "Content-Type": "application/json",
+  let response: Response;
+  try {
+    response = await fetch(
+      `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(appId)}/sessions/new`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${appSecret}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
       },
-      body: JSON.stringify({}),
-    },
-  );
+    );
+  } catch {
+    return c.json({ error: CallsErrorKeys.TOKEN_FAILED }, 502);
+  }
 
   if (!response.ok) {
-    return c.json({ error: "calls_token_failed" }, 502);
+    return c.json({ error: CallsErrorKeys.TOKEN_FAILED }, 502);
   }
 
-  const data = await response.json<{
-    sessionId: string;
-    sessionToken: string;
-  }>();
-  return c.json({ sessionId: data.sessionId, sessionToken: data.sessionToken });
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return c.json({ error: CallsErrorKeys.UPSTREAM_INVALID }, 502);
+  }
+
+  const parsed = CallsSessionTokenResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: CallsErrorKeys.UPSTREAM_INVALID }, 502);
+  }
+
+  return c.json(parsed.data);
 });

--- a/packages/worker/src/routes/calls.ts
+++ b/packages/worker/src/routes/calls.ts
@@ -1,0 +1,52 @@
+import { Hono } from "hono";
+
+type Bindings = {
+  CF_CALLS_APP_ID?: string;
+  CF_CALLS_APP_SECRET?: string;
+};
+
+export const callsRoutes = new Hono<{ Bindings: Bindings }>();
+
+const getSubject = (c: {
+  req: { header: (name: string) => string | undefined };
+}): string | null => {
+  const subject = c.req.header("x-subject")?.trim();
+  return subject || null;
+};
+
+// POST /token — Exchange credentials with Cloudflare Calls API and return session token
+callsRoutes.post("/token", async (c) => {
+  const subject = getSubject(c);
+  if (!subject) {
+    return c.json({ error: "calls.auth_required" }, 401);
+  }
+
+  const appId = c.env?.CF_CALLS_APP_ID;
+  const appSecret = c.env?.CF_CALLS_APP_SECRET;
+
+  if (!appId || !appSecret) {
+    return c.json({ error: "calls_not_configured" }, 501);
+  }
+
+  const response = await fetch(
+    `https://rtc.live.cloudflare.com/v1/apps/${appId}/sessions/new`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${appSecret}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    },
+  );
+
+  if (!response.ok) {
+    return c.json({ error: "calls_token_failed" }, 502);
+  }
+
+  const data = await response.json<{
+    sessionId: string;
+    sessionToken: string;
+  }>();
+  return c.json({ sessionId: data.sessionId, sessionToken: data.sessionToken });
+});

--- a/packages/worker/src/routes/leaderboard.ts
+++ b/packages/worker/src/routes/leaderboard.ts
@@ -1,6 +1,7 @@
-import type {
-  LeaderboardCompletionsEntry,
-  LeaderboardWinsEntry,
+import {
+  LeaderboardCompletionsResponseSchema,
+  LeaderboardErrorKeys,
+  LeaderboardWinsResponseSchema,
 } from "@oligopoly/validation";
 import { Hono } from "hono";
 
@@ -22,8 +23,19 @@ leaderboardRoutes.get("/wins", async (c) => {
     return c.json({ entries: [] });
   }
 
-  const entries = JSON.parse(raw) as LeaderboardWinsEntry[];
-  return c.json({ entries });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return c.json({ error: LeaderboardErrorKeys.INVALID_DATA }, 500);
+  }
+
+  const result = LeaderboardWinsResponseSchema.safeParse({ entries: parsed });
+  if (!result.success) {
+    return c.json({ error: LeaderboardErrorKeys.INVALID_DATA }, 500);
+  }
+
+  return c.json(result.data);
 });
 
 // GET /completions — Return leaderboard ranked by completions
@@ -38,6 +50,19 @@ leaderboardRoutes.get("/completions", async (c) => {
     return c.json({ entries: [] });
   }
 
-  const entries = JSON.parse(raw) as LeaderboardCompletionsEntry[];
-  return c.json({ entries });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return c.json({ error: LeaderboardErrorKeys.INVALID_DATA }, 500);
+  }
+
+  const result = LeaderboardCompletionsResponseSchema.safeParse({
+    entries: parsed,
+  });
+  if (!result.success) {
+    return c.json({ error: LeaderboardErrorKeys.INVALID_DATA }, 500);
+  }
+
+  return c.json(result.data);
 });

--- a/packages/worker/src/routes/leaderboard.ts
+++ b/packages/worker/src/routes/leaderboard.ts
@@ -1,0 +1,43 @@
+import type {
+  LeaderboardCompletionsEntry,
+  LeaderboardWinsEntry,
+} from "@oligopoly/validation";
+import { Hono } from "hono";
+
+type Bindings = {
+  KV?: KVNamespace;
+};
+
+export const leaderboardRoutes = new Hono<{ Bindings: Bindings }>();
+
+// GET /wins — Return leaderboard ranked by wins
+leaderboardRoutes.get("/wins", async (c) => {
+  const kv = c.env?.KV;
+  if (!kv) {
+    return c.json({ entries: [] });
+  }
+
+  const raw = await kv.get("leaderboard:wins");
+  if (!raw) {
+    return c.json({ entries: [] });
+  }
+
+  const entries = JSON.parse(raw) as LeaderboardWinsEntry[];
+  return c.json({ entries });
+});
+
+// GET /completions — Return leaderboard ranked by completions
+leaderboardRoutes.get("/completions", async (c) => {
+  const kv = c.env?.KV;
+  if (!kv) {
+    return c.json({ entries: [] });
+  }
+
+  const raw = await kv.get("leaderboard:completions");
+  if (!raw) {
+    return c.json({ entries: [] });
+  }
+
+  const entries = JSON.parse(raw) as LeaderboardCompletionsEntry[];
+  return c.json({ entries });
+});

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -1,0 +1,170 @@
+import app from "@oligopoly/worker";
+import { describe, expect, it } from "vitest";
+
+const createKvStub = () => {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string, _opts?: unknown) => {
+      store.set(key, value);
+    },
+    _store: store,
+  } as unknown as KVNamespace;
+};
+
+const requestWithEnv = (
+  path: string,
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+    kv?: KVNamespace;
+    callsAppId?: string;
+    callsAppSecret?: string;
+  } = {},
+) => {
+  const {
+    method = "GET",
+    headers = {},
+    body,
+    kv,
+    callsAppId,
+    callsAppSecret,
+  } = options;
+  const init: RequestInit = { method, headers: { ...headers } };
+  if (body) {
+    (init.headers as Record<string, string>)["Content-Type"] =
+      "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return app.request(path, init, {
+    ALLOWED_ORIGINS: "http://localhost:5173",
+    KV: kv,
+    CF_CALLS_APP_ID: callsAppId,
+    CF_CALLS_APP_SECRET: callsAppSecret,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Leaderboard — wins
+// ---------------------------------------------------------------------------
+
+describe("GET /api/leaderboard/wins", () => {
+  it("returns empty entries array when KV is absent", async () => {
+    const res = await requestWithEnv("/api/leaderboard/wins");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ entries: [] });
+  });
+
+  it("returns empty entries array when KV key is not set", async () => {
+    const kv = createKvStub();
+    const res = await requestWithEnv("/api/leaderboard/wins", { kv });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ entries: [] });
+  });
+
+  it("returns entries from KV when populated", async () => {
+    const kv = createKvStub();
+    const entries = [
+      { userId: "user-1", username: "Alice", wins: 10 },
+      { userId: "user-2", username: "Bob", wins: 7 },
+    ];
+    await kv.put("leaderboard:wins", JSON.stringify(entries));
+
+    const res = await requestWithEnv("/api/leaderboard/wins", { kv });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].userId).toBe("user-1");
+    expect(body.entries[0].username).toBe("Alice");
+    expect(body.entries[0].wins).toBe(10);
+    expect(body.entries[1].userId).toBe("user-2");
+    expect(body.entries[1].wins).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leaderboard — completions
+// ---------------------------------------------------------------------------
+
+describe("GET /api/leaderboard/completions", () => {
+  it("returns empty entries array when KV is absent", async () => {
+    const res = await requestWithEnv("/api/leaderboard/completions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ entries: [] });
+  });
+
+  it("returns empty entries array when KV key is not set", async () => {
+    const kv = createKvStub();
+    const res = await requestWithEnv("/api/leaderboard/completions", { kv });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ entries: [] });
+  });
+
+  it("returns entries from KV when populated", async () => {
+    const kv = createKvStub();
+    const entries = [
+      { userId: "user-3", username: "Carol", completions: 25 },
+      { userId: "user-4", username: "Dave", completions: 18 },
+    ];
+    await kv.put("leaderboard:completions", JSON.stringify(entries));
+
+    const res = await requestWithEnv("/api/leaderboard/completions", { kv });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].userId).toBe("user-3");
+    expect(body.entries[0].username).toBe("Carol");
+    expect(body.entries[0].completions).toBe(25);
+    expect(body.entries[1].completions).toBe(18);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Calls token
+// ---------------------------------------------------------------------------
+
+describe("POST /api/calls/token", () => {
+  it("returns 401 without auth", async () => {
+    const res = await requestWithEnv("/api/calls/token", { method: "POST" });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain("auth_required");
+  });
+
+  it("returns 501 when CF_CALLS_APP_ID and CF_CALLS_APP_SECRET are absent", async () => {
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+    });
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.error).toBe("calls_not_configured");
+  });
+
+  it("returns 501 when only CF_CALLS_APP_ID is set", async () => {
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppId: "test-app-id",
+    });
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.error).toBe("calls_not_configured");
+  });
+
+  it("returns 501 when only CF_CALLS_APP_SECRET is set", async () => {
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppSecret: "test-secret",
+    });
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.error).toBe("calls_not_configured");
+  });
+});

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -1,5 +1,5 @@
 import app from "@oligopoly/worker";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createKvStub = () => {
   const store = new Map<string, string>();
@@ -83,6 +83,30 @@ describe("GET /api/leaderboard/wins", () => {
     expect(body.entries[1].userId).toBe("user-2");
     expect(body.entries[1].wins).toBe(7);
   });
+
+  it("returns 500 with typed error when KV value is malformed JSON", async () => {
+    const kv = createKvStub();
+    await kv.put("leaderboard:wins", "this is not json{{{");
+
+    const res = await requestWithEnv("/api/leaderboard/wins", { kv });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("leaderboard.invalid_data");
+  });
+
+  it("returns 500 with typed error when KV value has wrong shape", async () => {
+    const kv = createKvStub();
+    // Array of objects missing required fields
+    await kv.put(
+      "leaderboard:wins",
+      JSON.stringify([{ userId: "u1", wins: "not-a-number" }]),
+    );
+
+    const res = await requestWithEnv("/api/leaderboard/wins", { kv });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("leaderboard.invalid_data");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -122,6 +146,29 @@ describe("GET /api/leaderboard/completions", () => {
     expect(body.entries[0].completions).toBe(25);
     expect(body.entries[1].completions).toBe(18);
   });
+
+  it("returns 500 with typed error when KV value is malformed JSON", async () => {
+    const kv = createKvStub();
+    await kv.put("leaderboard:completions", "<<<bad json>>>");
+
+    const res = await requestWithEnv("/api/leaderboard/completions", { kv });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("leaderboard.invalid_data");
+  });
+
+  it("returns 500 with typed error when KV value has wrong shape", async () => {
+    const kv = createKvStub();
+    await kv.put(
+      "leaderboard:completions",
+      JSON.stringify([{ userId: "u1", completions: "oops" }]),
+    );
+
+    const res = await requestWithEnv("/api/leaderboard/completions", { kv });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("leaderboard.invalid_data");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -129,11 +176,19 @@ describe("GET /api/leaderboard/completions", () => {
 // ---------------------------------------------------------------------------
 
 describe("POST /api/calls/token", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("returns 401 without auth", async () => {
     const res = await requestWithEnv("/api/calls/token", { method: "POST" });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toContain("auth_required");
+    expect(body.error).toBe("calls.auth_required");
   });
 
   it("returns 501 when CF_CALLS_APP_ID and CF_CALLS_APP_SECRET are absent", async () => {
@@ -143,7 +198,7 @@ describe("POST /api/calls/token", () => {
     });
     expect(res.status).toBe(501);
     const body = await res.json();
-    expect(body.error).toBe("calls_not_configured");
+    expect(body.error).toBe("calls.not_configured");
   });
 
   it("returns 501 when only CF_CALLS_APP_ID is set", async () => {
@@ -154,7 +209,7 @@ describe("POST /api/calls/token", () => {
     });
     expect(res.status).toBe(501);
     const body = await res.json();
-    expect(body.error).toBe("calls_not_configured");
+    expect(body.error).toBe("calls.not_configured");
   });
 
   it("returns 501 when only CF_CALLS_APP_SECRET is set", async () => {
@@ -165,6 +220,94 @@ describe("POST /api/calls/token", () => {
     });
     expect(res.status).toBe(501);
     const body = await res.json();
-    expect(body.error).toBe("calls_not_configured");
+    expect(body.error).toBe("calls.not_configured");
+  });
+
+  it("returns 502 when Cloudflare Calls API returns a non-ok status", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }),
+    );
+
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppId: "my-app-id",
+      callsAppSecret: "my-secret",
+    });
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("calls.token_failed");
+  });
+
+  it("returns 502 when Cloudflare Calls API fetch throws (network error)", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network failure"));
+
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppId: "my-app-id",
+      callsAppSecret: "my-secret",
+    });
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("calls.token_failed");
+  });
+
+  it("returns 502 when Cloudflare response body has unexpected shape", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ unexpected: "shape" }), { status: 200 }),
+    );
+
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppId: "my-app-id",
+      callsAppSecret: "my-secret",
+    });
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("calls.upstream_invalid");
+  });
+
+  it("returns 200 with sessionId and sessionToken on success", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          sessionId: "sess-abc-123",
+          sessionToken: "tok-xyz-456",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const res = await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppId: "my-app-id",
+      callsAppSecret: "my-secret",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessionId).toBe("sess-abc-123");
+    expect(body.sessionToken).toBe("tok-xyz-456");
+  });
+
+  it("uses encodeURIComponent on the app ID in the upstream URL", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ sessionId: "s", sessionToken: "t" }), {
+        status: 200,
+      }),
+    );
+
+    await requestWithEnv("/api/calls/token", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      callsAppId: "app/id with spaces",
+      callsAppSecret: "secret",
+    });
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("app%2Fid%20with%20spaces");
+    expect(calledUrl).not.toContain("app/id with spaces");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #10

## Summary

Implements the leaderboard and Cloudflare Calls token routes as specified in issue #10, with all review issues from the follow-up code review addressed.

## Changes

### `@oligopoly/validation`
- Added `LeaderboardEntrySchema` as a shared base extended by `LeaderboardWinsEntrySchema` and `LeaderboardCompletionsEntrySchema` (counts now have `.nonnegative()` constraint)
- Added `LeaderboardErrorKeys` (`leaderboard.invalid_data`) for typed error responses
- Added `CallsSessionTokenResponseSchema` for runtime validation of the Cloudflare Calls API response shape
- Added `CallsErrorKeys` registry (`calls.auth_required`, `calls.not_configured`, `calls.token_failed`, `calls.upstream_invalid`) — replaces bare string literals

### `packages/worker/src/routes/leaderboard.ts` (new)
- `GET /wins` and `GET /completions` — public endpoints reading from KV
- `JSON.parse` wrapped in try/catch; returns `500 leaderboard.invalid_data` on invalid JSON instead of propagating an unhandled exception
- KV data validated with `safeParse` against Zod response schema; returns `500 leaderboard.invalid_data` on shape mismatch
- Returns `{ entries: [] }` gracefully when KV is absent or key is unset

### `packages/worker/src/routes/calls.ts` (new)
- `POST /token` — auth required via `x-subject` header
- Uses `CallsErrorKeys` constants throughout
- `encodeURIComponent(appId)` used when building the upstream URL
- `fetch()` wrapped in try/catch; returns `502 calls.token_failed` on network error
- Cloudflare response body validated with `CallsSessionTokenResponseSchema.safeParse`; returns `502 calls.upstream_invalid` if shape is unexpected

### `packages/worker/src/index.ts`
- Extended `Bindings` with `CF_CALLS_APP_ID` and `CF_CALLS_APP_SECRET`
- Mounted `leaderboardRoutes` at `/api/leaderboard` and `callsRoutes` at `/api/calls`

### `tests/integration/leaderboard.test.ts` (19 tests)
- Leaderboard wins/completions: empty KV, missing key, populated KV, malformed JSON → 500, wrong schema shape → 500
- Calls token: 401 no auth, 501 both vars absent, 501 only one var set, 502 upstream non-ok, 502 network error, 502 wrong response shape, 200 success path, `encodeURIComponent` URL verification

## Test Results

```
✓ tests/integration/leaderboard.test.ts (19 tests)
✓ All 74 integration tests pass
✓ TypeScript typecheck clean
✓ Biome lint clean
```

## Planning Doc Notes

- `oligopoly_technical_plan.md` §"Backend Runtime and Route Contracts" — confirmed route table entries for all three endpoints
- `oligopoly_technical_plan.md` §"Data Model and Persistence" — confirmed KV key names `leaderboard:wins` and `leaderboard:completions`
- `oligopoly_technical_plan.md` §"Environment Configuration" — confirmed `CF_CALLS_APP_ID` and `CF_CALLS_APP_SECRET`
- `oligopoly_game_rules.md` — no updates needed
- Neither planning doc required updates
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://oligopoly-enterprise.slack.com/archives/C0ANWCMRR38/p1774664026795279?thread_ts=1774664026.795279&cid=C0ANWCMRR38)

<div><a href="https://cursor.com/agents/bc-5bdcd215-0978-5373-936b-a4b31c7a9b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bdcd215-0978-5373-936b-a4b31c7a9b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

