### PR TITLE
chore: upgrade workspace to TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@vitest/coverage-v8": "^3.2.4",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.2",
     "vitest": "^3.0.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "jsdom": "^29.0.1",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.2",
     "vite": "^6.0.0",
     "vitest": "^3.0.0"
   }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -7,11 +7,14 @@
     "jsx": "react-jsx",
     "noEmit": true,
     "types": ["vite/client", "vitest/globals"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
   },
   "include": ["src", "src/vite-env.d.ts"],
-  "references": [{ "path": "../validation" }]
+  "references": [
+    {
+      "path": "../validation"
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(jiti@2.6.1)(jsdom@29.0.1))
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(jiti@2.6.1)(jsdom@29.0.1)
@@ -70,8 +70,8 @@ importers:
         specifier: ^29.0.1
         version: 29.0.1
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       vite:
         specifier: ^6.0.0
         version: 6.4.1(jiti@2.6.1)
@@ -1695,8 +1695,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3238,7 +3238,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici@7.24.4: {}
 


### PR DESCRIPTION
### Motivation
- Bring the repository toolchain up to the latest TypeScript 6 release to eliminate deprecation warnings and keep developer tooling current.
- Resolve a TypeScript 6 deprecation error caused by a deprecated `baseUrl` option in a package tsconfig so `tsc --build` succeeds.
- This is a tooling/dependency change only and does not change gameplay/runtime behavior described in the planning docs.

### Description
- Bumped TypeScript in the root `package.json` and `packages/web/package.json` to `^6.0.2` and regenerated the lockfile so importers resolve to `typescript@6.0.2` (updated `pnpm-lock.yaml`).
- Removed the deprecated `baseUrl` entry from `packages/web/tsconfig.json` while preserving the `paths` alias to satisfy TypeScript 6 rules.
- Reformatted the `packages/web/tsconfig.json` include/references array for consistency.
- Confirmed this change is tooling-only after checking `oligopoly_technical_plan.md` and `oligopoly_game_rules.md`, so no docs updates were required.

### Testing
- Verified latest TypeScript with `npm view typescript version` which returned `6.0.2`.
- Ran `pnpm install` to update the lockfile and dependency graph, which completed successfully.
- Ran `pnpm run typecheck` (`tsc --build`) after fixes, which succeeded.
- Ran `pnpm run lint` and `pnpm run test:unit` (Vitest) and all unit tests passed (`99` tests passed), and linting completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73af2847083319f285b30583e88b8)