### PR TITLE
fix(ci): resolve PR #36 lint/format failures

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,46 @@
+# Review Guidelines
+
+## Pre-commit checks
+
+Before committing, verify the following pass locally:
+
+```
+pnpm run lint        # Biome lint + format + import ordering
+pnpm run typecheck   # TypeScript project references build
+pnpm run test:unit   # Unit tests
+pnpm run test:integration  # Integration tests
+```
+
+## HTTP status codes
+
+- **401** — Use for any unauthenticated request (missing auth context, no `x-subject` header, auth adapter not configured). Every authenticated route in the codebase follows this pattern. Do **not** use 501 for missing auth.
+- **403** — Use when the user is authenticated but lacks the required role or permission (e.g., not a `global_admin`).
+- **501** — Reserve for features that are genuinely not implemented (e.g., hosted-only stubs like impersonate, session invalidation, or the `/api/auth/*` catch-all).
+- **404** — Use when a specific resource (user, game, lobby) is not found.
+- **500** — Use when a required binding (DB, KV) is not configured.
+
+## Input validation
+
+- Always validate and sanitize query parameters. Numeric params like `page` should fall back to safe defaults for non-numeric, negative, or zero input (see `parsePage` in `packages/worker/src/routes/admin.ts`).
+- Escape SQL `LIKE` wildcards (`%`, `_`, `\`) in user-supplied search strings to prevent unintended pattern matching.
+- Verify target resources exist before performing mutations (e.g., check user exists before banning).
+
+## Performance
+
+- Prefer `Promise.all()` for independent I/O operations (DB queries, KV reads) instead of sequential `await` in loops.
+- Flag any database queries or KV reads inside loops as candidates for parallelization.
+
+## Naming and style
+
+- DB columns use `snake_case`; JSON API responses use `camelCase`. Map between them explicitly in route handlers.
+- Follow existing patterns in the codebase. Check nearby files for conventions before introducing new ones.
+- Use parameterized queries for all SQL — never interpolate user input into query strings.
+
+## Testing
+
+- Integration tests should cover: auth gating (401/403), happy path, 404 for missing resources, and side effects (KV writes, audit log inserts).
+- Test stubs (D1, KV) are simplified — they don't execute real SQL. Note this limitation when asserting on query behavior like `LIKE` filtering or `COUNT(*)`.
+
+## Planning docs
+
+See `AGENTS.md` for the full workflow around `oligopoly_technical_plan.md` and `oligopoly_game_rules.md`. Any behavior or contract changes must be reflected in those docs.

--- a/packages/worker/migrations/0003_add_user_role.sql
+++ b/packages/worker/migrations/0003_add_user_role.sql
@@ -1,0 +1,7 @@
+-- =============================================================================
+-- 0003_add_user_role.sql
+-- Adds a role column to the users table for global role-based access control.
+-- Default value is 'user'; admin accounts should be set to 'global_admin'.
+-- =============================================================================
+
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { banCacheMiddleware } from "./middleware/banCache";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
+import { adminRoutes } from "./routes/admin";
 import { gameRoutes } from "./routes/games";
 import { lobbyRoutes } from "./routes/lobbies";
 import { userRoutes } from "./routes/users";
@@ -57,6 +58,7 @@ app.all("/api/auth/*", (c) => {
   return c.json({ error: "Auth adapter not configured" }, 501);
 });
 
+app.route("/api/admin", adminRoutes);
 app.route("/api/games", gameRoutes);
 app.route("/api/users", userRoutes);
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -5,7 +5,9 @@ import { authSubjectMiddleware } from "./middleware/authSubject";
 import { banCacheMiddleware } from "./middleware/banCache";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import { adminRoutes } from "./routes/admin";
+import { callsRoutes } from "./routes/calls";
 import { gameRoutes } from "./routes/games";
+import { leaderboardRoutes } from "./routes/leaderboard";
 import { lobbyRoutes } from "./routes/lobbies";
 import { userRoutes } from "./routes/users";
 
@@ -13,6 +15,8 @@ type Bindings = {
   ALLOWED_ORIGINS?: string;
   DB?: D1Database;
   KV?: KVNamespace;
+  CF_CALLS_APP_ID?: string;
+  CF_CALLS_APP_SECRET?: string;
 };
 
 type Variables = {
@@ -68,6 +72,8 @@ app.all("/api/auth/*", (c) => {
 app.route("/api/admin", adminRoutes);
 app.route("/api/games", gameRoutes);
 app.route("/api/users", userRoutes);
+app.route("/api/leaderboard", leaderboardRoutes);
+app.route("/api/calls", callsRoutes);
 
 app.notFound((c) => {
   return c.json({ error: "Not found" }, 404);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,6 +1,7 @@
 import type { HealthResponse } from "@oligopoly/validation";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { authSubjectMiddleware } from "./middleware/authSubject";
 import { banCacheMiddleware } from "./middleware/banCache";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import { adminRoutes } from "./routes/admin";
@@ -14,7 +15,12 @@ type Bindings = {
   KV?: KVNamespace;
 };
 
-const app = new Hono<{ Bindings: Bindings }>();
+type Variables = {
+  userId?: string;
+  userRole?: string;
+};
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 app.use(
   "*",
@@ -29,6 +35,7 @@ app.use(
 );
 app.use("*", rateLimitMiddleware);
 app.use("*", banCacheMiddleware);
+app.use("*", authSubjectMiddleware);
 
 app.get("/api/health", (c) => {
   const response: HealthResponse = {

--- a/packages/worker/src/middleware/authSubject.ts
+++ b/packages/worker/src/middleware/authSubject.ts
@@ -1,0 +1,47 @@
+import type { MiddlewareHandler } from "hono";
+
+type AuthSubjectBindings = {
+  DB?: D1Database;
+};
+
+type AuthSubjectVariables = {
+  userId?: string;
+  userRole?: string;
+};
+
+const toValue = (value: string | null | undefined): string | null => {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+};
+
+/**
+ * Reads the interim `x-subject` header, looks up the user in D1, and
+ * populates `userId` and `userRole` on the Hono context.
+ *
+ * If the header is absent or the user is not found the middleware does
+ * nothing — downstream handlers decide how to react (401, 501, etc.).
+ */
+export const authSubjectMiddleware: MiddlewareHandler<{
+  Bindings: AuthSubjectBindings;
+  Variables: AuthSubjectVariables;
+}> = async (c, next) => {
+  const subject = toValue(c.req.header("x-subject"));
+
+  if (!subject || !c.env?.DB) {
+    await next();
+    return;
+  }
+
+  const row = await c.env.DB.prepare(
+    "SELECT id, role FROM users WHERE id = ?",
+  )
+    .bind(subject)
+    .first<{ id: string; role: string }>();
+
+  if (row) {
+    c.set("userId", row.id);
+    c.set("userRole", row.role);
+  }
+
+  await next();
+};

--- a/packages/worker/src/middleware/authSubject.ts
+++ b/packages/worker/src/middleware/authSubject.ts
@@ -32,9 +32,7 @@ export const authSubjectMiddleware: MiddlewareHandler<{
     return;
   }
 
-  const row = await c.env.DB.prepare(
-    "SELECT id, role FROM users WHERE id = ?",
-  )
+  const row = await c.env.DB.prepare("SELECT id, role FROM users WHERE id = ?")
     .bind(subject)
     .first<{ id: string; role: string }>();
 

--- a/packages/worker/src/middleware/requireAdmin.ts
+++ b/packages/worker/src/middleware/requireAdmin.ts
@@ -17,7 +17,7 @@ export const requireAdmin: MiddlewareHandler<{
   const role = c.get("userRole");
 
   if (role === undefined) {
-    return c.json({ error: "Auth adapter not configured" }, 501);
+    return c.json({ error: "Auth adapter not configured" }, 401);
   }
 
   if (role !== "global_admin") {

--- a/packages/worker/src/middleware/requireAdmin.ts
+++ b/packages/worker/src/middleware/requireAdmin.ts
@@ -1,0 +1,28 @@
+import type { MiddlewareHandler } from "hono";
+
+type AdminBindings = {
+  DB?: D1Database;
+  KV?: KVNamespace;
+};
+
+type AdminVariables = {
+  userId?: string;
+  userRole?: string;
+};
+
+export const requireAdmin: MiddlewareHandler<{
+  Bindings: AdminBindings;
+  Variables: AdminVariables;
+}> = async (c, next) => {
+  const role = c.get("userRole");
+
+  if (role === undefined) {
+    return c.json({ error: "Auth adapter not configured" }, 501);
+  }
+
+  if (role !== "global_admin") {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  await next();
+};

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -461,8 +461,9 @@ adminRoutes.get("/analytics/costs", async (c) => {
 
   const values = await Promise.all(dateKeys.map(({ key }) => kv.get(key)));
   for (let i = 0; i < dateKeys.length; i++) {
-    if (values[i] !== null) {
-      costs.push({ date: dateKeys[i].dateStr, cost: values[i]! });
+    const value = values[i];
+    if (typeof value === "string") {
+      costs.push({ date: dateKeys[i].dateStr, cost: value });
     }
   }
 

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -15,6 +15,11 @@ type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 const generateId = () => crypto.randomUUID();
 
+/** Escape SQL LIKE wildcards so user input is matched literally. */
+function escapeLike(input: string): string {
+  return input.replace(/[%_\\]/g, "\\$&");
+}
+
 // ---------------------------------------------------------------------------
 // Helper: write an entry to the admin_audit_log table
 // ---------------------------------------------------------------------------
@@ -66,8 +71,8 @@ adminRoutes.get("/users", async (c) => {
 
   if (search) {
     query =
-      "SELECT id, username, email, created_at, updated_at FROM users WHERE username LIKE ? OR email LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?";
-    const pattern = `%${search}%`;
+      "SELECT id, username, email, created_at, updated_at FROM users WHERE username LIKE ? ESCAPE '\\' OR email LIKE ? ESCAPE '\\' ORDER BY created_at DESC LIMIT ? OFFSET ?";
+    const pattern = `%${escapeLike(search)}%`;
     params = [pattern, pattern, limit, offset];
   } else {
     query =

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -388,13 +388,18 @@ adminRoutes.get("/analytics/costs", async (c) => {
   const costs: { date: string; cost: string }[] = [];
   const now = new Date();
 
+  const dateKeys: { dateStr: string; key: string }[] = [];
   for (let i = 0; i < 30; i++) {
     const date = new Date(now);
     date.setUTCDate(date.getUTCDate() - i);
     const dateStr = date.toISOString().slice(0, 10);
-    const value = await kv.get(`ai_cost:daily:${dateStr}`);
-    if (value !== null) {
-      costs.push({ date: dateStr, cost: value });
+    dateKeys.push({ dateStr, key: `ai_cost:daily:${dateStr}` });
+  }
+
+  const values = await Promise.all(dateKeys.map(({ key }) => kv.get(key)));
+  for (let i = 0; i < dateKeys.length; i++) {
+    if (values[i] !== null) {
+      costs.push({ date: dateKeys[i].dateStr, cost: values[i]! });
     }
   }
 

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -1,0 +1,442 @@
+import { Hono } from "hono";
+import { requireAdmin } from "../middleware/requireAdmin";
+
+type Bindings = {
+  DB?: D1Database;
+  KV?: KVNamespace;
+};
+
+type Variables = {
+  userId?: string;
+  userRole?: string;
+};
+
+type AppEnv = { Bindings: Bindings; Variables: Variables };
+
+const generateId = () => crypto.randomUUID();
+
+// ---------------------------------------------------------------------------
+// Helper: write an entry to the admin_audit_log table
+// ---------------------------------------------------------------------------
+async function writeAuditLog(
+  db: D1Database,
+  entry: {
+    adminId: string;
+    targetId: string | null;
+    action: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      "INSERT INTO admin_audit_log (id, admin_id, target_id, action, metadata_json, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(
+      generateId(),
+      entry.adminId,
+      entry.targetId,
+      entry.action,
+      entry.metadata ? JSON.stringify(entry.metadata) : null,
+      Date.now(),
+    )
+    .run();
+}
+
+export const adminRoutes = new Hono<AppEnv>();
+
+// Apply requireAdmin middleware to all admin routes
+adminRoutes.use("*", requireAdmin);
+
+// ---------------------------------------------------------------------------
+// GET /users — paginated list of all users; supports ?search=
+// ---------------------------------------------------------------------------
+adminRoutes.get("/users", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const search = c.req.query("search");
+  const page = Number(c.req.query("page") ?? "1");
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  let query: string;
+  let params: unknown[];
+
+  if (search) {
+    query =
+      "SELECT id, username, email, created_at, updated_at FROM users WHERE username LIKE ? OR email LIKE ? ORDER BY created_at DESC LIMIT ? OFFSET ?";
+    const pattern = `%${search}%`;
+    params = [pattern, pattern, limit, offset];
+  } else {
+    query =
+      "SELECT id, username, email, created_at, updated_at FROM users ORDER BY created_at DESC LIMIT ? OFFSET ?";
+    params = [limit, offset];
+  }
+
+  const { results } = await db
+    .prepare(query)
+    .bind(...params)
+    .all<{
+      id: string;
+      username: string;
+      email: string | null;
+      created_at: number;
+      updated_at: number;
+    }>();
+
+  return c.json({
+    users: results.map((row) => ({
+      id: row.id,
+      username: row.username,
+      email: row.email,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    })),
+    page,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /users/:id — full user record including email
+// ---------------------------------------------------------------------------
+adminRoutes.get("/users/:id", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const id = c.req.param("id");
+  const row = await db
+    .prepare("SELECT * FROM users WHERE id = ?")
+    .bind(id)
+    .first<{
+      id: string;
+      username: string;
+      avatar_url: string | null;
+      full_name: string | null;
+      email: string | null;
+      locale: string;
+      timezone: string | null;
+      currency: string | null;
+      country: string | null;
+      theme_preference: string;
+      created_at: number;
+      updated_at: number;
+    }>();
+
+  if (!row) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  return c.json({
+    id: row.id,
+    username: row.username,
+    avatarUrl: row.avatar_url,
+    fullName: row.full_name,
+    email: row.email,
+    locale: row.locale,
+    timezone: row.timezone,
+    currency: row.currency,
+    country: row.country,
+    themePreference: row.theme_preference,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /users/:id/ban — set ban flag in KV; write audit log
+// ---------------------------------------------------------------------------
+adminRoutes.post("/users/:id/ban", async (c) => {
+  const db = c.env?.DB;
+  const kv = c.env?.KV;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+  if (!kv) {
+    return c.json({ error: "KV not configured" }, 500);
+  }
+
+  const id = c.req.param("id");
+  const adminId = c.get("userId") ?? "unknown";
+
+  await kv.put(`ban:${id}`, "1");
+  await writeAuditLog(db, {
+    adminId,
+    targetId: id,
+    action: "ban_user",
+  });
+
+  return c.json({ ok: true }, 200);
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /users/:id/ban — remove ban flag from KV; write audit log
+// ---------------------------------------------------------------------------
+adminRoutes.delete("/users/:id/ban", async (c) => {
+  const db = c.env?.DB;
+  const kv = c.env?.KV;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+  if (!kv) {
+    return c.json({ error: "KV not configured" }, 500);
+  }
+
+  const id = c.req.param("id");
+  const adminId = c.get("userId") ?? "unknown";
+
+  await kv.delete(`ban:${id}`);
+  await writeAuditLog(db, {
+    adminId,
+    targetId: id,
+    action: "unban_user",
+  });
+
+  return c.json({ ok: true }, 200);
+});
+
+// ---------------------------------------------------------------------------
+// POST /users/:id/impersonate — audit log; return 501 (hosted-only)
+// ---------------------------------------------------------------------------
+adminRoutes.post("/users/:id/impersonate", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const id = c.req.param("id");
+  const adminId = c.get("userId") ?? "unknown";
+
+  await writeAuditLog(db, {
+    adminId,
+    targetId: id,
+    action: "impersonate_user",
+  });
+
+  return c.json({ error: "Impersonation is a hosted-only feature" }, 501);
+});
+
+// ---------------------------------------------------------------------------
+// POST /users/:id/sessions — invalidate sessions; return 501 (hosted-only)
+// ---------------------------------------------------------------------------
+adminRoutes.post("/users/:id/sessions", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const id = c.req.param("id");
+  const adminId = c.get("userId") ?? "unknown";
+
+  await writeAuditLog(db, {
+    adminId,
+    targetId: id,
+    action: "invalidate_sessions",
+  });
+
+  return c.json(
+    { error: "Session invalidation is a hosted-only feature" },
+    501,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// GET /games — paginated list of all games
+// ---------------------------------------------------------------------------
+adminRoutes.get("/games", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const page = Number(c.req.query("page") ?? "1");
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  const { results } = await db
+    .prepare(
+      "SELECT id, status, player_ids_json, started_at, ended_at, winner_id FROM games ORDER BY started_at DESC LIMIT ? OFFSET ?",
+    )
+    .bind(limit, offset)
+    .all<{
+      id: string;
+      status: string;
+      player_ids_json: string;
+      started_at: number;
+      ended_at: number | null;
+      winner_id: string | null;
+    }>();
+
+  return c.json({
+    games: results.map((row) => ({
+      id: row.id,
+      status: row.status,
+      playerCount: (JSON.parse(row.player_ids_json) as string[]).length,
+      startedAt: row.started_at,
+      endedAt: row.ended_at,
+      winnerId: row.winner_id,
+    })),
+    page,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /games/:id — full game record with log
+// ---------------------------------------------------------------------------
+adminRoutes.get("/games/:id", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const id = c.req.param("id");
+
+  const game = await db
+    .prepare(
+      "SELECT id, status, player_ids_json, started_at, ended_at, winner_id, state_json FROM games WHERE id = ?",
+    )
+    .bind(id)
+    .first<{
+      id: string;
+      status: string;
+      player_ids_json: string;
+      started_at: number;
+      ended_at: number | null;
+      winner_id: string | null;
+      state_json: string | null;
+    }>();
+
+  if (!game) {
+    return c.json({ error: "Game not found" }, 404);
+  }
+
+  const { results: logResults } = await db
+    .prepare(
+      "SELECT id, game_id, round, player_id, action_type, payload_json, created_at FROM game_log WHERE game_id = ? ORDER BY created_at ASC",
+    )
+    .bind(id)
+    .all<{
+      id: string;
+      game_id: string;
+      round: number;
+      player_id: string | null;
+      action_type: string;
+      payload_json: string | null;
+      created_at: number;
+    }>();
+
+  return c.json({
+    id: game.id,
+    status: game.status,
+    playerIds: JSON.parse(game.player_ids_json) as string[],
+    startedAt: game.started_at,
+    endedAt: game.ended_at,
+    winnerId: game.winner_id,
+    state: game.state_json ? JSON.parse(game.state_json) : null,
+    log: logResults.map((row) => ({
+      id: row.id,
+      gameId: row.game_id,
+      round: row.round,
+      playerId: row.player_id,
+      actionType: row.action_type,
+      payload: row.payload_json ? JSON.parse(row.payload_json) : null,
+      createdAt: row.created_at,
+    })),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /analytics — basic aggregate stats
+// ---------------------------------------------------------------------------
+adminRoutes.get("/analytics", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const [usersResult, gamesResult, activeGamesResult] = await Promise.all([
+    db
+      .prepare("SELECT COUNT(*) as count FROM users")
+      .first<{ count: number }>(),
+    db
+      .prepare("SELECT COUNT(*) as count FROM games")
+      .first<{ count: number }>(),
+    db
+      .prepare("SELECT COUNT(*) as count FROM games WHERE status = 'active'")
+      .first<{ count: number }>(),
+  ]);
+
+  return c.json({
+    totalUsers: usersResult?.count ?? 0,
+    totalGames: gamesResult?.count ?? 0,
+    activeGames: activeGamesResult?.count ?? 0,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /analytics/costs — AI cost tracking from KV (last 30 days)
+// ---------------------------------------------------------------------------
+adminRoutes.get("/analytics/costs", async (c) => {
+  const kv = c.env?.KV;
+  if (!kv) {
+    return c.json({ error: "KV not configured" }, 500);
+  }
+
+  const costs: { date: string; cost: string }[] = [];
+  const now = new Date();
+
+  for (let i = 0; i < 30; i++) {
+    const date = new Date(now);
+    date.setUTCDate(date.getUTCDate() - i);
+    const dateStr = date.toISOString().slice(0, 10);
+    const value = await kv.get(`ai_cost:daily:${dateStr}`);
+    if (value !== null) {
+      costs.push({ date: dateStr, cost: value });
+    }
+  }
+
+  return c.json({ costs });
+});
+
+// ---------------------------------------------------------------------------
+// GET /audit-log — paginated list of admin_audit_log entries
+// ---------------------------------------------------------------------------
+adminRoutes.get("/audit-log", async (c) => {
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const page = Number(c.req.query("page") ?? "1");
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  const { results } = await db
+    .prepare(
+      "SELECT id, admin_id, target_id, action, metadata_json, created_at FROM admin_audit_log ORDER BY created_at DESC LIMIT ? OFFSET ?",
+    )
+    .bind(limit, offset)
+    .all<{
+      id: string;
+      admin_id: string;
+      target_id: string | null;
+      action: string;
+      metadata_json: string | null;
+      created_at: number;
+    }>();
+
+  return c.json({
+    entries: results.map((row) => ({
+      id: row.id,
+      adminId: row.admin_id,
+      targetId: row.target_id,
+      action: row.action,
+      metadata: row.metadata_json ? JSON.parse(row.metadata_json) : null,
+      createdAt: row.created_at,
+    })),
+    page,
+  });
+});

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -15,6 +15,15 @@ type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 const generateId = () => crypto.randomUUID();
 
+/** Parse and validate the `page` query parameter. Returns 1 for invalid input. */
+function parsePage(raw: string | undefined): number {
+  const n = Number(raw ?? "1");
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return 1;
+  }
+  return n;
+}
+
 /** Escape SQL LIKE wildcards so user input is matched literally. */
 function escapeLike(input: string): string {
   return input.replace(/[%_\\]/g, "\\$&");
@@ -62,7 +71,7 @@ adminRoutes.get("/users", async (c) => {
   }
 
   const search = c.req.query("search");
-  const page = Number(c.req.query("page") ?? "1");
+  const page = parsePage(c.req.query("page"));
   const limit = 50;
   const offset = (page - 1) * limit;
 
@@ -273,7 +282,7 @@ adminRoutes.get("/games", async (c) => {
     return c.json({ error: "Database not configured" }, 500);
   }
 
-  const page = Number(c.req.query("page") ?? "1");
+  const page = parsePage(c.req.query("page"));
   const limit = 50;
   const offset = (page - 1) * limit;
 
@@ -436,7 +445,7 @@ adminRoutes.get("/audit-log", async (c) => {
     return c.json({ error: "Database not configured" }, 500);
   }
 
-  const page = Number(c.req.query("page") ?? "1");
+  const page = parsePage(c.req.query("page"));
   const limit = 50;
   const offset = (page - 1) * limit;
 

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -162,6 +162,14 @@ adminRoutes.post("/users/:id/ban", async (c) => {
   const id = c.req.param("id");
   const adminId = c.get("userId") ?? "unknown";
 
+  const user = await db
+    .prepare("SELECT id FROM users WHERE id = ?")
+    .bind(id)
+    .first<{ id: string }>();
+  if (!user) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
   await kv.put(`ban:${id}`, "1");
   await writeAuditLog(db, {
     adminId,
@@ -187,6 +195,14 @@ adminRoutes.delete("/users/:id/ban", async (c) => {
 
   const id = c.req.param("id");
   const adminId = c.get("userId") ?? "unknown";
+
+  const user = await db
+    .prepare("SELECT id FROM users WHERE id = ?")
+    .bind(id)
+    .first<{ id: string }>();
+  if (!user) {
+    return c.json({ error: "User not found" }, 404);
+  }
 
   await kv.delete(`ban:${id}`);
   await writeAuditLog(db, {

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -176,6 +176,10 @@ adminRoutes.post("/users/:id/ban", async (c) => {
   const id = c.req.param("id");
   const adminId = c.get("userId") ?? "unknown";
 
+  if (id === adminId) {
+    return c.json({ error: "Cannot ban yourself" }, 400);
+  }
+
   const user = await db
     .prepare("SELECT id FROM users WHERE id = ?")
     .bind(id)

--- a/packages/worker/src/routes/admin.ts
+++ b/packages/worker/src/routes/admin.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { requireAdmin } from "../middleware/requireAdmin";
 
 type Bindings = {
@@ -14,6 +15,33 @@ type Variables = {
 type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 const generateId = () => crypto.randomUUID();
+
+/** Schema for the `player_ids_json` column — must be an array of strings. */
+const playerIdsSchema = z.array(z.string());
+
+/** Safely parse a JSON string with a zod schema, returning a fallback on failure. */
+function safeParseJson<T>(
+  raw: string | null | undefined,
+  schema: z.ZodType<T>,
+  fallback: T,
+): T {
+  if (raw == null) return fallback;
+  try {
+    return schema.parse(JSON.parse(raw));
+  } catch {
+    return fallback;
+  }
+}
+
+/** Safely parse an arbitrary JSON string, returning `null` on failure. */
+function safeJsonParse(raw: string | null | undefined): unknown {
+  if (raw == null) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
 
 /** Parse and validate the `page` query parameter. Returns 1 for invalid input. */
 function parsePage(raw: string | undefined): number {
@@ -308,7 +336,8 @@ adminRoutes.get("/games", async (c) => {
     games: results.map((row) => ({
       id: row.id,
       status: row.status,
-      playerCount: (JSON.parse(row.player_ids_json) as string[]).length,
+      playerCount: safeParseJson(row.player_ids_json, playerIdsSchema, [])
+        .length,
       startedAt: row.started_at,
       endedAt: row.ended_at,
       winnerId: row.winner_id,
@@ -365,18 +394,18 @@ adminRoutes.get("/games/:id", async (c) => {
   return c.json({
     id: game.id,
     status: game.status,
-    playerIds: JSON.parse(game.player_ids_json) as string[],
+    playerIds: safeParseJson(game.player_ids_json, playerIdsSchema, []),
     startedAt: game.started_at,
     endedAt: game.ended_at,
     winnerId: game.winner_id,
-    state: game.state_json ? JSON.parse(game.state_json) : null,
+    state: safeJsonParse(game.state_json),
     log: logResults.map((row) => ({
       id: row.id,
       gameId: row.game_id,
       round: row.round,
       playerId: row.player_id,
       actionType: row.action_type,
-      payload: row.payload_json ? JSON.parse(row.payload_json) : null,
+      payload: safeJsonParse(row.payload_json),
       createdAt: row.created_at,
     })),
   });
@@ -473,7 +502,7 @@ adminRoutes.get("/audit-log", async (c) => {
       adminId: row.admin_id,
       targetId: row.target_id,
       action: row.action,
-      metadata: row.metadata_json ? JSON.parse(row.metadata_json) : null,
+      metadata: safeJsonParse(row.metadata_json),
       createdAt: row.created_at,
     })),
     page,

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -12,14 +12,18 @@ type Bindings = {
   DB?: D1Database;
 };
 
-type AppEnv = { Bindings: Bindings };
+type Variables = {
+  userId?: string;
+};
+
+type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 export const gameRoutes = new Hono<AppEnv>();
 
 // ---------------------------------------------------------------------------
 // GET /api/games
 // Returns a paginated list of games. Supports ?status=active|completed.
-// Auth is optional; when an x-subject header is present, results are filtered
+// Auth is optional; when the user is authenticated, results are filtered
 // to games the user participates in.
 // ---------------------------------------------------------------------------
 gameRoutes.get("/", async (c) => {
@@ -34,7 +38,7 @@ gameRoutes.get("/", async (c) => {
     return c.json({ games: [] as GameSummary[] });
   }
 
-  const subject = c.req.header("x-subject");
+  const subject = c.get("userId");
 
   let query: string;
   let params: (string | null)[];
@@ -131,12 +135,12 @@ gameRoutes.get("/:id", async (c) => {
 // ---------------------------------------------------------------------------
 // GET /api/games/:id/state
 // Returns the current game state snapshot.
-// Auth required (x-subject must be a player or spectator).
+// Auth required (user must be a player or spectator).
 // 403 for non-participants; 404 if game not found.
 // ---------------------------------------------------------------------------
 gameRoutes.get("/:id/state", async (c) => {
   const id = c.req.param("id");
-  const subject = c.req.header("x-subject");
+  const subject = c.get("userId");
 
   if (!subject) {
     return c.json({ error: "Unauthorized" }, 401);
@@ -179,7 +183,7 @@ gameRoutes.get("/:id/state", async (c) => {
 // ---------------------------------------------------------------------------
 gameRoutes.get("/:id/log", async (c) => {
   const id = c.req.param("id");
-  const subject = c.req.header("x-subject");
+  const subject = c.get("userId");
 
   if (!subject) {
     return c.json({ error: "Unauthorized" }, 401);
@@ -239,7 +243,7 @@ gameRoutes.get("/:id/log", async (c) => {
 // ---------------------------------------------------------------------------
 gameRoutes.get("/:id/replay", async (c) => {
   const id = c.req.param("id");
-  const subject = c.req.header("x-subject");
+  const subject = c.get("userId");
 
   if (!subject) {
     return c.json({ error: "Unauthorized" }, 401);

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -11,6 +11,10 @@ type Bindings = {
   KV?: KVNamespace;
 };
 
+type Variables = {
+  userId?: string;
+};
+
 type LobbyRow = {
   id: string;
   name: string;
@@ -32,10 +36,9 @@ type LobbyPlayerRow = {
 const generateId = () => crypto.randomUUID();
 
 const getSubject = (c: {
-  req: { header: (name: string) => string | undefined };
+  get: (key: string) => string | undefined;
 }): string | null => {
-  const subject = c.req.header("x-subject")?.trim();
-  return subject || null;
+  return c.get("userId") ?? null;
 };
 
 const toLobbyResponse = (row: LobbyRow, players: LobbyPlayerRow[] = []) => ({
@@ -56,7 +59,7 @@ const toLobbyResponse = (row: LobbyRow, players: LobbyPlayerRow[] = []) => ({
   })),
 });
 
-export const lobbyRoutes = new Hono<{ Bindings: Bindings }>();
+export const lobbyRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 // POST /  — Create a lobby
 lobbyRoutes.post("/", zValidator("json", CreateLobbyInputSchema), async (c) => {

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -59,7 +59,10 @@ const toLobbyResponse = (row: LobbyRow, players: LobbyPlayerRow[] = []) => ({
   })),
 });
 
-export const lobbyRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+export const lobbyRoutes = new Hono<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>();
 
 // POST /  — Create a lobby
 lobbyRoutes.post("/", zValidator("json", CreateLobbyInputSchema), async (c) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@oligopoly/worker':
         specifier: workspace:*
         version: link:../../packages/worker
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.9
 
   tests/unit:
     dependencies:

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -1,0 +1,490 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { adminRoutes } from "../../packages/worker/src/routes/admin";
+
+// ---------------------------------------------------------------------------
+// Minimal D1 stub
+// ---------------------------------------------------------------------------
+type Row = Record<string, unknown>;
+
+function makeDb(tables: Record<string, Row[]>) {
+  const inserted: Record<string, Row[]> = {};
+
+  const makeStmt = (query: string, boundParams: unknown[]) => ({
+    bind: (...args: unknown[]) => makeStmt(query, args),
+    async first<T>(): Promise<T | null> {
+      const table = inferTable(query);
+
+      // Handle COUNT(*) queries
+      if (query.includes("COUNT(*)")) {
+        const rows = tables[table] ?? [];
+        const filtered = applyWhere(rows, query, boundParams);
+        return { count: filtered.length } as T;
+      }
+
+      const rows = tables[table] ?? [];
+      const filtered = applyWhere(rows, query, boundParams);
+      return (filtered[0] as T) ?? null;
+    },
+    async all<T>(): Promise<{ results: T[] }> {
+      const table = inferTable(query);
+      const rows = tables[table] ?? [];
+      const filtered = applyWhere(rows, query, boundParams);
+      return { results: filtered as T[] };
+    },
+    async run(): Promise<void> {
+      // Track INSERT operations for audit log verification
+      if (query.startsWith("INSERT INTO")) {
+        const table = inferTable(query);
+        if (!inserted[table]) {
+          inserted[table] = [];
+        }
+        inserted[table].push(
+          Object.fromEntries(boundParams.map((v, i) => [`param_${i}`, v])),
+        );
+      }
+    },
+  });
+
+  return {
+    prepare: (query: string) => makeStmt(query, []),
+    _inserted: inserted,
+  };
+}
+
+function inferTable(query: string): string {
+  const fromMatch = query.match(/FROM\s+(\w+)/i);
+  if (fromMatch) return fromMatch[1];
+  const intoMatch = query.match(/INTO\s+(\w+)/i);
+  if (intoMatch) return intoMatch[1];
+  return "";
+}
+
+function applyWhere(rows: Row[], query: string, params: unknown[]): Row[] {
+  const idMatch = query.match(/WHERE\s+id\s*=\s*\?/i);
+  if (idMatch && params.length > 0) {
+    return rows.filter((r) => r.id === params[0]);
+  }
+
+  const gameIdMatch = query.match(/WHERE\s+game_id\s*=\s*\?/i);
+  if (gameIdMatch && params.length > 0) {
+    return rows.filter((r) => r.game_id === params[0]);
+  }
+
+  const statusMatch = query.match(/WHERE\s+status\s*=\s*'(\w+)'/i);
+  if (statusMatch) {
+    return rows.filter((r) => r.status === statusMatch[1]);
+  }
+
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal KV stub
+// ---------------------------------------------------------------------------
+function makeKv(store: Record<string, string> = {}) {
+  return {
+    get: async (key: string) => store[key] ?? null,
+    put: async (key: string, value: string) => {
+      store[key] = value;
+    },
+    delete: async (key: string) => {
+      delete store[key];
+    },
+  } as unknown as KVNamespace;
+}
+
+// ---------------------------------------------------------------------------
+// Seed data
+// ---------------------------------------------------------------------------
+const USER_A: Row = {
+  id: "user-a",
+  username: "alice",
+  avatar_url: null,
+  full_name: "Alice Admin",
+  email: "alice@example.com",
+  locale: "en",
+  timezone: "UTC",
+  currency: "USD",
+  country: "US",
+  theme_preference: "dark",
+  created_at: 1000,
+  updated_at: 1000,
+};
+
+const USER_B: Row = {
+  id: "user-b",
+  username: "bob",
+  avatar_url: null,
+  full_name: "Bob Regular",
+  email: "bob@example.com",
+  locale: "en",
+  timezone: "UTC",
+  currency: "EUR",
+  country: "DE",
+  theme_preference: "system",
+  created_at: 2000,
+  updated_at: 2000,
+};
+
+const GAME_A: Row = {
+  id: "game-a",
+  status: "active",
+  player_ids_json: JSON.stringify(["user-a", "user-b"]),
+  started_at: 3000,
+  ended_at: null,
+  winner_id: null,
+  state_json: JSON.stringify({ gameId: "game-a", round: 5 }),
+};
+
+const LOG_ENTRY: Row = {
+  id: "log-1",
+  game_id: "game-a",
+  round: 1,
+  player_id: "user-a",
+  action_type: "roll_dice",
+  payload_json: JSON.stringify({ result: [2, 3] }),
+  created_at: 3001,
+};
+
+const AUDIT_ENTRY: Row = {
+  id: "audit-1",
+  admin_id: "admin-user",
+  target_id: "user-b",
+  action: "ban_user",
+  metadata_json: null,
+  created_at: 5000,
+};
+
+function makeEnv(overrides: { kvStore?: Record<string, string> } = {}) {
+  const kvStore = overrides.kvStore ?? {};
+  return {
+    DB: makeDb({
+      users: [USER_A, USER_B],
+      games: [GAME_A],
+      game_log: [LOG_ENTRY],
+      admin_audit_log: [AUDIT_ENTRY],
+    }),
+    KV: makeKv(kvStore),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper to make admin requests
+// ---------------------------------------------------------------------------
+type WrapperEnv = {
+  Bindings: { DB?: D1Database; KV?: KVNamespace };
+  Variables: { userId?: string; userRole?: string };
+};
+
+function adminRequest(
+  path: string,
+  options: {
+    method?: string;
+    env?: ReturnType<typeof makeEnv>;
+    role?: string;
+    userId?: string;
+  } = {},
+) {
+  const env = options.env ?? makeEnv();
+  const method = options.method ?? "GET";
+  const { role, userId } = options;
+
+  const wrapper = new Hono<WrapperEnv>();
+
+  wrapper.use("*", async (c, next) => {
+    if (role !== undefined) {
+      c.set("userRole", role);
+    }
+    if (userId !== undefined) {
+      c.set("userId", userId);
+    }
+    await next();
+  });
+
+  wrapper.route("/api/admin", adminRoutes);
+
+  return wrapper.request(path, { method }, env);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: requireAdmin middleware
+// ---------------------------------------------------------------------------
+describe("requireAdmin middleware", () => {
+  it("returns 501 when no auth adapter is configured (no userRole set)", async () => {
+    const res = await adminRequest("/api/admin/users", {
+      role: undefined,
+    });
+    expect(res.status).toBe(501);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("not configured");
+  });
+
+  it("returns 403 when user is not a global_admin", async () => {
+    const res = await adminRequest("/api/admin/users", {
+      role: "regular",
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("allows access for global_admin role", async () => {
+    const res = await adminRequest("/api/admin/users", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/users
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/users", () => {
+  it("returns paginated user list", async () => {
+    const res = await adminRequest("/api/admin/users", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{ users: unknown[]; page: number }>();
+    expect(Array.isArray(body.users)).toBe(true);
+    expect(body.page).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/users/:id
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/users/:id", () => {
+  it("returns full user record for known ID", async () => {
+    const res = await adminRequest("/api/admin/users/user-a", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{ id: string; email: string | null }>();
+    expect(body.id).toBe("user-a");
+    expect(body.email).toBe("alice@example.com");
+  });
+
+  it("returns 404 for unknown user", async () => {
+    const res = await adminRequest("/api/admin/users/nonexistent", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: POST /api/admin/users/:id/ban
+// ---------------------------------------------------------------------------
+describe("POST /api/admin/users/:id/ban", () => {
+  it("sets ban flag in KV", async () => {
+    const kvStore: Record<string, string> = {};
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/user-b/ban", {
+      method: "POST",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(200);
+    expect(kvStore["ban:user-b"]).toBe("1");
+  });
+
+  it("writes audit log entry on ban", async () => {
+    const kvStore: Record<string, string> = {};
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/user-b/ban", {
+      method: "POST",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(200);
+
+    // Verify audit log was written
+    const db = env.DB as ReturnType<typeof makeDb>;
+    const auditInserts = db._inserted.admin_audit_log;
+    expect(auditInserts).toBeDefined();
+    expect(auditInserts.length).toBeGreaterThan(0);
+
+    // Check that the last audit entry contains the expected action
+    const lastEntry = auditInserts[auditInserts.length - 1];
+    expect(lastEntry.param_1).toBe("admin-user"); // admin_id
+    expect(lastEntry.param_2).toBe("user-b"); // target_id
+    expect(lastEntry.param_3).toBe("ban_user"); // action
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /api/admin/users/:id/ban
+// ---------------------------------------------------------------------------
+describe("DELETE /api/admin/users/:id/ban", () => {
+  it("removes ban flag from KV", async () => {
+    const kvStore: Record<string, string> = { "ban:user-b": "1" };
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/user-b/ban", {
+      method: "DELETE",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(200);
+    expect(kvStore["ban:user-b"]).toBeUndefined();
+  });
+
+  it("writes audit log entry on unban", async () => {
+    const kvStore: Record<string, string> = { "ban:user-b": "1" };
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/user-b/ban", {
+      method: "DELETE",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(200);
+
+    const db = env.DB as ReturnType<typeof makeDb>;
+    const auditInserts = db._inserted.admin_audit_log;
+    expect(auditInserts).toBeDefined();
+    expect(auditInserts.length).toBeGreaterThan(0);
+
+    const lastEntry = auditInserts[auditInserts.length - 1];
+    expect(lastEntry.param_3).toBe("unban_user");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: POST /api/admin/users/:id/impersonate
+// ---------------------------------------------------------------------------
+describe("POST /api/admin/users/:id/impersonate", () => {
+  it("returns 501 (hosted-only feature)", async () => {
+    const res = await adminRequest("/api/admin/users/user-b/impersonate", {
+      method: "POST",
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(501);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: POST /api/admin/users/:id/sessions
+// ---------------------------------------------------------------------------
+describe("POST /api/admin/users/:id/sessions", () => {
+  it("returns 501 (hosted-only feature)", async () => {
+    const res = await adminRequest("/api/admin/users/user-b/sessions", {
+      method: "POST",
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(501);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/games
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/games", () => {
+  it("returns paginated games list", async () => {
+    const res = await adminRequest("/api/admin/games", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{ games: unknown[]; page: number }>();
+    expect(Array.isArray(body.games)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/games/:id
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/games/:id", () => {
+  it("returns full game record with log", async () => {
+    const res = await adminRequest("/api/admin/games/game-a", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      id: string;
+      log: unknown[];
+    }>();
+    expect(body.id).toBe("game-a");
+    expect(Array.isArray(body.log)).toBe(true);
+  });
+
+  it("returns 404 for unknown game", async () => {
+    const res = await adminRequest("/api/admin/games/nonexistent", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/analytics
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/analytics", () => {
+  it("returns aggregate stats", async () => {
+    const res = await adminRequest("/api/admin/analytics", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      totalUsers: number;
+      totalGames: number;
+      activeGames: number;
+    }>();
+    expect(typeof body.totalUsers).toBe("number");
+    expect(typeof body.totalGames).toBe("number");
+    expect(typeof body.activeGames).toBe("number");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/analytics/costs
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/analytics/costs", () => {
+  it("returns cost data from KV", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const kvStore: Record<string, string> = {
+      [`ai_cost:daily:${today}`]: "12.50",
+    };
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/analytics/costs", {
+      role: "global_admin",
+      env,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      costs: { date: string; cost: string }[];
+    }>();
+    expect(Array.isArray(body.costs)).toBe(true);
+    expect(body.costs.length).toBeGreaterThan(0);
+    expect(body.costs[0].date).toBe(today);
+    expect(body.costs[0].cost).toBe("12.50");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/admin/audit-log
+// ---------------------------------------------------------------------------
+describe("GET /api/admin/audit-log", () => {
+  it("returns paginated audit log entries", async () => {
+    const res = await adminRequest("/api/admin/audit-log", {
+      role: "global_admin",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      entries: unknown[];
+      page: number;
+    }>();
+    expect(Array.isArray(body.entries)).toBe(true);
+    expect(body.page).toBe(1);
+  });
+});

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -292,6 +292,20 @@ describe("POST /api/admin/users/:id/ban", () => {
     expect(kvStore["ban:user-b"]).toBe("1");
   });
 
+  it("returns 404 when banning a nonexistent user", async () => {
+    const kvStore: Record<string, string> = {};
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/nonexistent/ban", {
+      method: "POST",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(404);
+    expect(kvStore["ban:nonexistent"]).toBeUndefined();
+  });
+
   it("writes audit log entry on ban", async () => {
     const kvStore: Record<string, string> = {};
     const env = makeEnv({ kvStore });
@@ -334,6 +348,21 @@ describe("DELETE /api/admin/users/:id/ban", () => {
     });
     expect(res.status).toBe(200);
     expect(kvStore["ban:user-b"]).toBeUndefined();
+  });
+
+  it("returns 404 when unbanning a nonexistent user", async () => {
+    const kvStore: Record<string, string> = { "ban:nonexistent": "1" };
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/nonexistent/ban", {
+      method: "DELETE",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(404);
+    // KV should remain untouched
+    expect(kvStore["ban:nonexistent"]).toBe("1");
   });
 
   it("writes audit log entry on unban", async () => {

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -211,11 +211,11 @@ function adminRequest(
 // Tests: requireAdmin middleware
 // ---------------------------------------------------------------------------
 describe("requireAdmin middleware", () => {
-  it("returns 501 when no auth adapter is configured (no userRole set)", async () => {
+  it("returns 401 when no auth adapter is configured (no userRole set)", async () => {
     const res = await adminRequest("/api/admin/users", {
       role: undefined,
     });
-    expect(res.status).toBe(501);
+    expect(res.status).toBe(401);
     const body = await res.json<{ error: string }>();
     expect(body.error).toContain("not configured");
   });

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -292,6 +292,22 @@ describe("POST /api/admin/users/:id/ban", () => {
     expect(kvStore["ban:user-b"]).toBe("1");
   });
 
+  it("returns 400 when admin tries to ban themselves", async () => {
+    const kvStore: Record<string, string> = {};
+    const env = makeEnv({ kvStore });
+
+    const res = await adminRequest("/api/admin/users/admin-user/ban", {
+      method: "POST",
+      env,
+      role: "global_admin",
+      userId: "admin-user",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("Cannot ban yourself");
+    expect(kvStore["ban:admin-user"]).toBeUndefined();
+  });
+
   it("returns 404 when banning a nonexistent user", async () => {
     const kvStore: Record<string, string> = {};
     const env = makeEnv({ kvStore });

--- a/tests/integration/games.test.ts
+++ b/tests/integration/games.test.ts
@@ -95,9 +95,28 @@ const logEntryCompleted: Row = {
   created_at: 501,
 };
 
+const userA: Row = {
+  id: PLAYER_A,
+  username: "player-a",
+  role: "user",
+};
+
+const userB: Row = {
+  id: PLAYER_B,
+  username: "player-b",
+  role: "user",
+};
+
+const outsiderUser: Row = {
+  id: "outsider",
+  username: "outsider",
+  role: "user",
+};
+
 function makeEnv(extraTables: Record<string, Row[]> = {}) {
   return {
     DB: makeDb({
+      users: [userA, userB, outsiderUser],
       games: [activeGame, completedGame],
       game_log: [logEntry, logEntryCompleted],
       ...extraTables,

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -9,6 +9,11 @@ type Row = Record<string, unknown>;
 
 const createD1Stub = () => {
   const tables: Record<string, Row[]> = {
+    users: [
+      { id: "user-1", username: "user-1", role: "user" },
+      { id: "user-2", username: "user-2", role: "user" },
+      { id: "user-3", username: "user-3", role: "user" },
+    ],
     lobbies: [],
     lobby_players: [],
   };
@@ -164,6 +169,20 @@ const createD1Stub = () => {
         (r) => !(r.lobby_id === binds[0] && r.user_id === binds[1]),
       );
       return { results: [], success: true };
+    }
+
+    // SELECT id, role FROM users WHERE id = ? (authSubjectMiddleware)
+    if (trimmed.startsWith("SELECT id, role FROM users WHERE id = ?")) {
+      const row = tables.users.find((r) => r.id === binds[0]) ?? null;
+      return { results: row ? [row] : [], first: row };
+    }
+
+    // SELECT COUNT(*) as cnt FROM lobby_players WHERE lobby_id = ?
+    if (trimmed.includes("COUNT(*)")) {
+      const rows = tables.lobby_players.filter(
+        (r) => r.lobby_id === binds[0],
+      );
+      return { results: [{ cnt: rows.length }], first: { cnt: rows.length } };
     }
 
     return { results: [] };

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -179,9 +179,7 @@ const createD1Stub = () => {
 
     // SELECT COUNT(*) as cnt FROM lobby_players WHERE lobby_id = ?
     if (trimmed.includes("COUNT(*)")) {
-      const rows = tables.lobby_players.filter(
-        (r) => r.lobby_id === binds[0],
-      );
+      const rows = tables.lobby_players.filter((r) => r.lobby_id === binds[0]);
       return { results: [{ cnt: rows.length }], first: { cnt: rows.length } };
     }
 

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@oligopoly/shared": "workspace:*",
     "@oligopoly/validation": "workspace:*",
-    "@oligopoly/worker": "workspace:*"
+    "@oligopoly/worker": "workspace:*",
+    "hono": "^4.7.0"
   }
 }

--- a/tests/integration/users.test.ts
+++ b/tests/integration/users.test.ts
@@ -83,6 +83,7 @@ const SAMPLE_USER = {
   currency: "USD",
   country: "US",
   theme_preference: "dark",
+  role: "user",
   created_at: 1000000,
   updated_at: 1000000,
 };
@@ -243,16 +244,14 @@ describe("GET /api/users/:id/viewer", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns ViewerUserProfile when authenticated via x-subject", async () => {
-    // The app uses x-subject for rate limiting but does NOT populate userId from it
-    // per the current implementation. The /viewer route returns 401 without auth adapter.
-    // This test verifies the 401 behavior is consistent.
+  it("returns 401 when x-subject user does not exist in DB", async () => {
+    // authSubjectMiddleware looks up x-subject in D1. Since "user-2" is not
+    // in the mock users table, userId is never set and the route returns 401.
     const res = await app.request(
       "/api/users/user-1/viewer",
       { headers: { "x-subject": "user-2" } },
       makeEnv(),
     );
-    // Without auth adapter, returns 401
     expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reproduced the failing CI job locally (`pnpm run lint`) from the PR #36 merge state.
- Removed a forbidden non-null assertion in `packages/worker/src/routes/admin.ts` by narrowing the KV value type before pushing to `costs`.
- Applied Biome formatting fixes in the three files flagged by CI:
  - `packages/worker/src/middleware/authSubject.ts`
  - `packages/worker/src/routes/lobbies.ts`
  - `tests/integration/lobbies.test.ts`

## Validation
- `pnpm run lint`
- `pnpm run --filter @oligopoly/validation build && pnpm run --filter @oligopoly/shared build`
- `pnpm run typecheck`
- `pnpm run test:integration`

## Notes
- This is a CI-hygiene fix only; no gameplay/runtime contract behavior was changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bfd2019-4cfd-4a64-94bd-5f061df06871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bfd2019-4cfd-4a64-94bd-5f061df06871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

