### PR TITLE
Implement create/join/start lobby game flow across worker and web

### DIFF
--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -24,4 +24,15 @@ describe("App", () => {
       screen.getByRole("heading", { level: 1, name: /^games$/i }),
     ).toBeInTheDocument();
   });
+
+  it("navigates to lobbies route", () => {
+    render(
+      <MemoryRouter initialEntries={["/lobbies"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole("heading", { level: 1, name: /^lobbies$/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,12 +4,14 @@ import { DevPage } from "./pages/DevPage";
 import { GameDetailPage } from "./pages/GameDetailPage";
 import { GamesPage } from "./pages/GamesPage";
 import { HomePage } from "./pages/HomePage";
+import { LobbiesPage } from "./pages/LobbiesPage";
 
 export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
         <Route path="/" element={<HomePage />} />
+        <Route path="/lobbies" element={<LobbiesPage />} />
         <Route path="/dev" element={<DevPage />} />
         <Route path="/games" element={<GamesPage />} />
         <Route path="/games/:id" element={<GameDetailPage />} />

--- a/packages/web/src/api/http.ts
+++ b/packages/web/src/api/http.ts
@@ -12,10 +12,10 @@ export class ApiError extends Error {
 }
 
 /**
- * GET JSON and validate with a Zod schema. Throws {@link ApiError} on HTTP or parse failure.
- * For routes that require `x-subject`, add header support here when `/api/auth/*` is wired.
+ * Fetch JSON and validate with a Zod schema.
+ * Throws {@link ApiError} on HTTP or parse failure.
  */
-export async function getJson<T>(
+export async function requestJson<T>(
   url: string,
   schema: ZodType<T>,
   init?: RequestInit,
@@ -51,4 +51,15 @@ export async function getJson<T>(
     );
   }
   return parsed.data;
+}
+
+/**
+ * Convenience helper for simple GET requests.
+ */
+export function getJson<T>(
+  url: string,
+  schema: ZodType<T>,
+  init?: RequestInit,
+): Promise<T> {
+  return requestJson(url, schema, init);
 }

--- a/packages/web/src/api/lobbies.ts
+++ b/packages/web/src/api/lobbies.ts
@@ -1,0 +1,125 @@
+import type { LobbyStatus } from "@oligopoly/validation";
+import { z } from "zod";
+import { env } from "../env";
+import { ApiError, requestJson } from "./http";
+
+const LobbyPlayerSchema = z.object({
+  userId: z.string(),
+  isAdmin: z.boolean(),
+  joinedAt: z.number(),
+});
+
+const LobbySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  hostId: z.string(),
+  status: z.enum(["waiting", "starting", "in_game", "finished"]),
+  maxPlayers: z.number().int().min(2).max(6),
+  isPrivate: z.boolean(),
+  optionalRuleIds: z.array(z.string()),
+  createdAt: z.number(),
+  players: z.array(LobbyPlayerSchema),
+  gameId: z.string().optional(),
+});
+
+const LobbiesListResponseSchema = z.object({
+  lobbies: z.array(LobbySchema),
+  nextCursor: z.string().nullable(),
+});
+
+const CreateLobbyInputSchema = z.object({
+  name: z.string().min(1).max(64),
+  maxPlayers: z.number().int().min(2).max(6),
+  isPrivate: z.boolean(),
+  optionalRuleIds: z.array(z.string()),
+});
+
+const StartLobbyResponseSchema = LobbySchema.extend({
+  gameId: z.string(),
+});
+
+const InviteResponseSchema = z.object({
+  token: z.string(),
+  expiresInSeconds: z.number(),
+});
+
+export type Lobby = z.infer<typeof LobbySchema> & { status: LobbyStatus };
+export type CreateLobbyInput = z.infer<typeof CreateLobbyInputSchema>;
+export type StartLobbyResponse = z.infer<typeof StartLobbyResponseSchema>;
+export type LobbiesListResponse = z.infer<typeof LobbiesListResponseSchema>;
+export { ApiError };
+
+const subjectHeaders = (subject: string) => ({
+  "x-subject": subject,
+});
+
+export function listPublicLobbies() {
+  return requestJson(`${env.apiUrl}/api/lobbies`, LobbiesListResponseSchema);
+}
+
+export function fetchLobby(lobbyId: string) {
+  return requestJson(
+    `${env.apiUrl}/api/lobbies/${encodeURIComponent(lobbyId)}`,
+    LobbySchema,
+  );
+}
+
+export function createLobby(input: CreateLobbyInput, subject: string) {
+  const payload = CreateLobbyInputSchema.parse(input);
+  return requestJson(`${env.apiUrl}/api/lobbies`, LobbySchema, {
+    method: "POST",
+    headers: {
+      ...subjectHeaders(subject),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function joinLobby(lobbyId: string, subject: string) {
+  return requestJson(
+    `${env.apiUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/join`,
+    LobbySchema,
+    {
+      method: "POST",
+      headers: subjectHeaders(subject),
+    },
+  );
+}
+
+export function joinLobbyWithToken(
+  lobbyId: string,
+  token: string,
+  subject: string,
+) {
+  return requestJson(
+    `${env.apiUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/join/${encodeURIComponent(token)}`,
+    LobbySchema,
+    {
+      method: "POST",
+      headers: subjectHeaders(subject),
+    },
+  );
+}
+
+export function createInviteToken(lobbyId: string, subject: string) {
+  return requestJson(
+    `${env.apiUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/invite`,
+    InviteResponseSchema,
+    {
+      method: "POST",
+      headers: subjectHeaders(subject),
+    },
+  );
+}
+
+export function startLobby(lobbyId: string, subject: string) {
+  return requestJson(
+    `${env.apiUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/start`,
+    StartLobbyResponseSchema,
+    {
+      method: "POST",
+      headers: subjectHeaders(subject),
+    },
+  );
+}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -21,6 +21,14 @@ export function Layout() {
             </li>
             <li>
               <NavLink
+                to="/lobbies"
+                className={({ isActive }) => (isActive ? "active" : undefined)}
+              >
+                Lobbies
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
                 to="/games"
                 className={({ isActive }) => (isActive ? "active" : undefined)}
               >

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -11,11 +11,14 @@ export function HomePage() {
       <div className="card">
         <h2>Play</h2>
         <p className="muted" style={{ marginBottom: "1rem" }}>
-          Browse active and completed games backed by the worker API.
+          Create, join, and start a lobby before entering a game.
         </p>
-        <Link to="/games" className="button">
-          View games
+        <Link to="/lobbies" className="button">
+          Open lobbies
         </Link>
+        <p className="muted" style={{ marginTop: "0.75rem", marginBottom: 0 }}>
+          You can still browse all games from the Games tab.
+        </p>
       </div>
       <div className="card">
         <h2>Developers</h2>

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -1,0 +1,448 @@
+import type { LobbyStatus } from "@oligopoly/validation";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+  ApiError,
+  createLobby,
+  fetchLobby,
+  joinLobby,
+  joinLobbyWithToken,
+  listPublicLobbies,
+  startLobby,
+} from "../api/lobbies";
+
+const DEFAULT_MAX_PLAYERS = 4;
+
+type Message = { kind: "ok" | "error"; text: string } | null;
+
+const canStartLobby = (status: LobbyStatus, playerCount: number) =>
+  status === "waiting" && playerCount >= 2;
+
+export function LobbiesPage() {
+  const [searchParams] = useSearchParams();
+  const initialLobbyId = searchParams.get("id")?.trim() ?? "";
+
+  const [subject, setSubject] = useState("user-1");
+  const [createName, setCreateName] = useState("New Lobby");
+  const [createMaxPlayers, setCreateMaxPlayers] = useState(DEFAULT_MAX_PLAYERS);
+  const [createIsPrivate, setCreateIsPrivate] = useState(false);
+
+  const [joinLobbyId, setJoinLobbyId] = useState(initialLobbyId);
+  const [joinToken, setJoinToken] = useState("");
+
+  const [loadingPublicLobbies, setLoadingPublicLobbies] = useState(true);
+  const [publicLobbies, setPublicLobbies] = useState<
+    Awaited<ReturnType<typeof listPublicLobbies>>["lobbies"]
+  >([]);
+  const [selectedLobby, setSelectedLobby] = useState<
+    Awaited<ReturnType<typeof fetchLobby>> | null
+  >(null);
+
+  const [busyCreate, setBusyCreate] = useState(false);
+  const [busyJoin, setBusyJoin] = useState(false);
+  const [busyStart, setBusyStart] = useState(false);
+  const [message, setMessage] = useState<Message>(null);
+
+  const selectedLobbyId = selectedLobby?.id ?? joinLobbyId;
+
+  const refreshPublicLobbies = async () => {
+    setLoadingPublicLobbies(true);
+    try {
+      const data = await listPublicLobbies();
+      setPublicLobbies(data.lobbies);
+    } catch (error) {
+      setMessage({
+        kind: "error",
+        text:
+          error instanceof ApiError
+            ? `Failed to load public lobbies: ${error.message}`
+            : "Failed to load public lobbies",
+      });
+    } finally {
+      setLoadingPublicLobbies(false);
+    }
+  };
+
+  const refreshSelectedLobby = async (id: string) => {
+    if (!id) {
+      setSelectedLobby(null);
+      return;
+    }
+    try {
+      const lobby = await fetchLobby(id);
+      setSelectedLobby(lobby);
+      setJoinLobbyId(lobby.id);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        setSelectedLobby(null);
+        setMessage({ kind: "error", text: "Lobby not found." });
+        return;
+      }
+      setMessage({
+        kind: "error",
+        text:
+          error instanceof ApiError
+            ? `Failed to load lobby: ${error.message}`
+            : "Failed to load lobby",
+      });
+    }
+  };
+
+  useEffect(() => {
+    void refreshPublicLobbies();
+  }, []);
+
+  useEffect(() => {
+    if (initialLobbyId) {
+      void refreshSelectedLobby(initialLobbyId);
+    }
+  }, [initialLobbyId]);
+
+  const isCurrentSubjectAdmin = useMemo(() => {
+    if (!selectedLobby) return false;
+    return selectedLobby.players.some(
+      (player) => player.userId === subject && player.isAdmin,
+    );
+  }, [selectedLobby, subject]);
+
+  const onCreateLobby = async () => {
+    setBusyCreate(true);
+    setMessage(null);
+    try {
+      const lobby = await createLobby(
+        {
+          name: createName.trim(),
+          maxPlayers: createMaxPlayers,
+          isPrivate: createIsPrivate,
+          optionalRuleIds: [],
+        },
+        subject,
+      );
+      setSelectedLobby(lobby);
+      setJoinLobbyId(lobby.id);
+      setMessage({ kind: "ok", text: `Created lobby ${lobby.id}` });
+      await refreshPublicLobbies();
+    } catch (error) {
+      setMessage({
+        kind: "error",
+        text:
+          error instanceof ApiError
+            ? `Create failed: ${error.message}`
+            : "Create failed",
+      });
+    } finally {
+      setBusyCreate(false);
+    }
+  };
+
+  const onLoadLobby = async () => {
+    setMessage(null);
+    await refreshSelectedLobby(joinLobbyId.trim());
+  };
+
+  const onJoinLobby = async () => {
+    const targetLobbyId = joinLobbyId.trim();
+    if (!targetLobbyId) {
+      setMessage({ kind: "error", text: "Lobby ID is required." });
+      return;
+    }
+
+    setBusyJoin(true);
+    setMessage(null);
+    try {
+      const lobby = joinToken.trim()
+        ? await joinLobbyWithToken(targetLobbyId, joinToken.trim(), subject)
+        : await joinLobby(targetLobbyId, subject);
+      setSelectedLobby(lobby);
+      setJoinLobbyId(lobby.id);
+      setMessage({ kind: "ok", text: `Joined lobby ${lobby.id}` });
+      await refreshPublicLobbies();
+    } catch (error) {
+      setMessage({
+        kind: "error",
+        text:
+          error instanceof ApiError
+            ? `Join failed: ${error.message}`
+            : "Join failed",
+      });
+    } finally {
+      setBusyJoin(false);
+    }
+  };
+
+  const onStartLobby = async () => {
+    if (!selectedLobbyId) return;
+    setBusyStart(true);
+    setMessage(null);
+    try {
+      const response = await startLobby(selectedLobbyId, subject);
+      await refreshSelectedLobby(selectedLobbyId);
+      await refreshPublicLobbies();
+      if (response.gameId) {
+        setMessage({
+          kind: "ok",
+          text: `Game started: ${response.gameId}`,
+        });
+      } else {
+        setMessage({ kind: "ok", text: "Lobby start requested." });
+      }
+    } catch (error) {
+      setMessage({
+        kind: "error",
+        text:
+          error instanceof ApiError
+            ? `Start failed: ${error.message}`
+            : "Start failed",
+      });
+    } finally {
+      setBusyStart(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="pageTitle">Lobbies</h1>
+      <p className="tagline">
+        Create, join, and start games through the Worker lobby API.
+      </p>
+
+      <div className="card">
+        <h2>Session</h2>
+        <label className="fieldLabel" htmlFor="subject">
+          Acting user (x-subject)
+        </label>
+        <input
+          id="subject"
+          className="textInput"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        />
+      </div>
+
+      <div className="card">
+        <h2>Create lobby</h2>
+        <div className="formGrid">
+          <div>
+            <label className="fieldLabel" htmlFor="create-name">
+              Name
+            </label>
+            <input
+              id="create-name"
+              className="textInput"
+              value={createName}
+              onChange={(e) => setCreateName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="fieldLabel" htmlFor="create-max">
+              Max players
+            </label>
+            <select
+              id="create-max"
+              className="textInput"
+              value={createMaxPlayers}
+              onChange={(e) => setCreateMaxPlayers(Number(e.target.value))}
+            >
+              {[2, 3, 4, 5, 6].map((count) => (
+                <option key={count} value={count}>
+                  {count}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <label className="checkboxRow">
+          <input
+            type="checkbox"
+            checked={createIsPrivate}
+            onChange={(e) => setCreateIsPrivate(e.target.checked)}
+          />
+          Private lobby
+        </label>
+        <button
+          type="button"
+          className="button"
+          disabled={busyCreate || !subject.trim() || !createName.trim()}
+          onClick={onCreateLobby}
+        >
+          {busyCreate ? "Creating…" : "Create lobby"}
+        </button>
+      </div>
+
+      <div className="card">
+        <h2>Join or load lobby</h2>
+        <div className="formGrid">
+          <div>
+            <label className="fieldLabel" htmlFor="join-id">
+              Lobby ID
+            </label>
+            <input
+              id="join-id"
+              className="textInput"
+              value={joinLobbyId}
+              onChange={(e) => setJoinLobbyId(e.target.value)}
+              placeholder="Paste lobby id"
+            />
+          </div>
+          <div>
+            <label className="fieldLabel" htmlFor="join-token">
+              Invite token (private lobbies)
+            </label>
+            <input
+              id="join-token"
+              className="textInput"
+              value={joinToken}
+              onChange={(e) => setJoinToken(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+        </div>
+        <div className="buttonRow">
+          <button
+            type="button"
+            className="button buttonSecondary"
+            onClick={onLoadLobby}
+            disabled={!joinLobbyId.trim()}
+          >
+            Load lobby
+          </button>
+          <button
+            type="button"
+            className="button"
+            onClick={onJoinLobby}
+            disabled={busyJoin || !subject.trim() || !joinLobbyId.trim()}
+          >
+            {busyJoin ? "Joining…" : "Join lobby"}
+          </button>
+        </div>
+      </div>
+
+      <div className="card">
+        <h2>Public lobbies</h2>
+        {loadingPublicLobbies && <p className="muted">Loading…</p>}
+        {!loadingPublicLobbies && publicLobbies.length === 0 && (
+          <p className="emptyState">No public lobbies available.</p>
+        )}
+        {!loadingPublicLobbies && publicLobbies.length > 0 && (
+          <table className="gamesTable">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Players</th>
+                <th>Status</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {publicLobbies.map((lobby) => (
+                <tr key={lobby.id}>
+                  <td>{lobby.name}</td>
+                  <td>
+                    {lobby.players.length}/{lobby.maxPlayers}
+                  </td>
+                  <td>{lobby.status}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="button buttonSecondary"
+                      onClick={() => {
+                        setJoinLobbyId(lobby.id);
+                        void refreshSelectedLobby(lobby.id);
+                      }}
+                    >
+                      Select
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="card">
+        <h2>Selected lobby</h2>
+        {!selectedLobby && (
+          <p className="emptyState">
+            Select a lobby above or create one to view details.
+          </p>
+        )}
+        {selectedLobby && (
+          <>
+            <dl className="detailsGrid">
+              <dt className="muted">Lobby ID</dt>
+              <dd>
+                <code className="inline">{selectedLobby.id}</code>
+              </dd>
+              <dt className="muted">Status</dt>
+              <dd>{selectedLobby.status}</dd>
+              <dt className="muted">Host</dt>
+              <dd>{selectedLobby.hostId}</dd>
+              <dt className="muted">Visibility</dt>
+              <dd>{selectedLobby.isPrivate ? "Private" : "Public"}</dd>
+              <dt className="muted">Players</dt>
+              <dd>
+                {selectedLobby.players.length}/{selectedLobby.maxPlayers}
+              </dd>
+            </dl>
+
+            <h3 className="subheading">Players</h3>
+            <ul className="plainList">
+              {selectedLobby.players.map((player) => (
+                <li key={player.userId}>
+                  <code className="inline">{player.userId}</code>
+                  {player.isAdmin ? " (admin)" : ""}
+                </li>
+              ))}
+            </ul>
+
+            <div className="buttonRow">
+              <button
+                type="button"
+                className="button"
+                onClick={onStartLobby}
+                disabled={
+                  busyStart ||
+                  !isCurrentSubjectAdmin ||
+                  !canStartLobby(
+                    selectedLobby.status,
+                    selectedLobby.players.length,
+                  )
+                }
+              >
+                {busyStart ? "Starting…" : "Start game"}
+              </button>
+              <button
+                type="button"
+                className="button buttonSecondary"
+                onClick={() => void refreshSelectedLobby(selectedLobby.id)}
+              >
+                Refresh lobby
+              </button>
+            </div>
+            <p className="muted">
+              Start is enabled for admins when the lobby is waiting and has at
+              least two players.
+            </p>
+          </>
+        )}
+      </div>
+
+      {selectedLobby?.status === "in_game" && (
+        <div className="card">
+          <h2>Next step</h2>
+          <p className="muted">
+            Lobby started. Open <Link to="/games">Games</Link> to inspect active
+            games.
+          </p>
+        </div>
+      )}
+
+      {message && (
+        <p className={message.kind === "error" ? "errorText" : "ok"}>
+          {message.text}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -1,5 +1,5 @@
 import type { LobbyStatus } from "@oligopoly/validation";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import {
   ApiError,
@@ -34,9 +34,9 @@ export function LobbiesPage() {
   const [publicLobbies, setPublicLobbies] = useState<
     Awaited<ReturnType<typeof listPublicLobbies>>["lobbies"]
   >([]);
-  const [selectedLobby, setSelectedLobby] = useState<
-    Awaited<ReturnType<typeof fetchLobby>> | null
-  >(null);
+  const [selectedLobby, setSelectedLobby] = useState<Awaited<
+    ReturnType<typeof fetchLobby>
+  > | null>(null);
 
   const [busyCreate, setBusyCreate] = useState(false);
   const [busyJoin, setBusyJoin] = useState(false);
@@ -45,7 +45,7 @@ export function LobbiesPage() {
 
   const selectedLobbyId = selectedLobby?.id ?? joinLobbyId;
 
-  const refreshPublicLobbies = async () => {
+  const refreshPublicLobbies = useCallback(async () => {
     setLoadingPublicLobbies(true);
     try {
       const data = await listPublicLobbies();
@@ -61,9 +61,9 @@ export function LobbiesPage() {
     } finally {
       setLoadingPublicLobbies(false);
     }
-  };
+  }, []);
 
-  const refreshSelectedLobby = async (id: string) => {
+  const refreshSelectedLobby = useCallback(async (id: string) => {
     if (!id) {
       setSelectedLobby(null);
       return;
@@ -86,17 +86,17 @@ export function LobbiesPage() {
             : "Failed to load lobby",
       });
     }
-  };
+  }, []);
 
   useEffect(() => {
     void refreshPublicLobbies();
-  }, []);
+  }, [refreshPublicLobbies]);
 
   useEffect(() => {
     if (initialLobbyId) {
       void refreshSelectedLobby(initialLobbyId);
     }
-  }, [initialLobbyId]);
+  }, [initialLobbyId, refreshSelectedLobby]);
 
   const isCurrentSubjectAdmin = useMemo(() => {
     if (!selectedLobby) return false;

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -185,6 +185,42 @@ code.inline {
   font-weight: 600;
 }
 
+.formGrid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.formGrid label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--color-muted);
+  font-size: 0.92rem;
+}
+
+.textInput,
+.selectInput {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--color-card-border);
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--color-text);
+  padding: 0.55rem 0.7rem;
+}
+
+.checkboxRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  color: var(--color-text);
+}
+
+.buttonRow {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .button {
   background: linear-gradient(
     90deg,
@@ -209,6 +245,11 @@ code.inline {
   background: transparent;
   border: 1px solid var(--color-card-border);
   color: var(--color-text);
+}
+
+.buttonDanger {
+  border-color: rgba(244, 67, 54, 0.55);
+  color: var(--color-error);
 }
 
 .linkList {

--- a/packages/worker/src/middleware/authSubject.ts
+++ b/packages/worker/src/middleware/authSubject.ts
@@ -32,8 +32,7 @@ export const authSubjectMiddleware: MiddlewareHandler<{
     return;
   }
 
-  const row = await c.env.DB
-    .prepare("SELECT id, role FROM users WHERE id = ?")
+  const row = await c.env.DB.prepare("SELECT id, role FROM users WHERE id = ?")
     .bind(subject)
     .first<{ id: string; role: string }>();
   if (row) {

--- a/packages/worker/src/middleware/authSubject.ts
+++ b/packages/worker/src/middleware/authSubject.ts
@@ -32,10 +32,10 @@ export const authSubjectMiddleware: MiddlewareHandler<{
     return;
   }
 
-  const row = await c.env.DB.prepare("SELECT id, role FROM users WHERE id = ?")
+  const row = await c.env.DB
+    .prepare("SELECT id, role FROM users WHERE id = ?")
     .bind(subject)
     .first<{ id: string; role: string }>();
-
   if (row) {
     c.set("userId", row.id);
     c.set("userRole", row.role);

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -37,14 +37,8 @@ const generateId = () => crypto.randomUUID();
 
 const getSubject = (c: {
   get: (key: string) => string | undefined;
-  req: { header: (name: string) => string | undefined };
 }): string | null => {
-  const contextSubject = c.get("userId");
-  if (contextSubject) {
-    return contextSubject;
-  }
-  const headerSubject = c.req.header("x-subject")?.trim();
-  return headerSubject ? headerSubject : null;
+  return c.get("userId") ?? null;
 };
 
 const toLobbyResponse = (row: LobbyRow, players: LobbyPlayerRow[] = []) => ({

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -37,8 +37,14 @@ const generateId = () => crypto.randomUUID();
 
 const getSubject = (c: {
   get: (key: string) => string | undefined;
+  req: { header: (name: string) => string | undefined };
 }): string | null => {
-  return c.get("userId") ?? null;
+  const contextSubject = c.get("userId");
+  if (contextSubject) {
+    return contextSubject;
+  }
+  const headerSubject = c.req.header("x-subject")?.trim();
+  return headerSubject ? headerSubject : null;
 };
 
 const toLobbyResponse = (row: LobbyRow, players: LobbyPlayerRow[] = []) => ({
@@ -603,21 +609,54 @@ lobbyRoutes.post("/:id/start", async (c) => {
     .bind(id)
     .all<LobbyPlayerRow>();
 
-  if (playersResult.results.length < 2) {
+  const lobbyPlayers = playersResult.results;
+  if (lobbyPlayers.length < 2) {
     return c.json({ error: LobbyErrorKeys.NOT_ENOUGH_PLAYERS }, 409);
   }
 
-  await db
-    .prepare("UPDATE lobbies SET status = 'starting' WHERE id = ?")
-    .bind(id)
-    .run();
+  const gameId = generateId();
+  const gameStartedLogId = generateId();
+  const now = Date.now();
+  const playerIds = [...lobbyPlayers]
+    .sort((a, b) => a.joined_at - b.joined_at)
+    .map((p) => p.user_id);
+
+  await db.batch([
+    db
+      .prepare(
+        `INSERT INTO games (id, lobby_id, status, started_at, ended_at, winner_id, player_ids_json, state_json)
+         VALUES (?, ?, 'active', ?, NULL, NULL, ?, ?)`,
+      )
+      .bind(
+        gameId,
+        id,
+        now,
+        JSON.stringify(playerIds),
+        JSON.stringify({ gameId, round: 1 }),
+      ),
+    db
+      .prepare(
+        `INSERT INTO game_log (id, game_id, round, player_id, action_type, payload_json, created_at)
+         VALUES (?, ?, 1, NULL, 'game_started', ?, ?)`,
+      )
+      .bind(
+        gameStartedLogId,
+        gameId,
+        JSON.stringify({ lobbyId: id, startedBy: subject, playerIds }),
+        now,
+      ),
+    db.prepare("UPDATE lobbies SET status = 'in_game' WHERE id = ?").bind(id),
+  ]);
 
   const updated = {
     ...lobby,
-    status: "starting",
+    status: "in_game",
   };
 
-  return c.json(toLobbyResponse(updated, playersResult.results));
+  return c.json({
+    ...toLobbyResponse(updated, lobbyPlayers),
+    gameId,
+  });
 });
 
 // GET /:id/ws — WebSocket stub (returns 501)

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -16,6 +16,8 @@ const createD1Stub = () => {
     ],
     lobbies: [],
     lobby_players: [],
+    games: [],
+    game_log: [],
   };
 
   const execSql = (sql: string, binds: unknown[]) => {
@@ -133,11 +135,59 @@ const createD1Stub = () => {
       return { results: rows };
     }
 
-    // UPDATE lobbies SET status = 'starting' WHERE id = ?
-    if (trimmed.startsWith("UPDATE lobbies SET status = 'starting'")) {
-      const row = tables.lobbies.find((r) => r.id === binds[0]);
-      if (row) row.status = "starting";
+    // INSERT INTO games
+    if (trimmed.startsWith("INSERT INTO games")) {
+      const [id, lobby_id, started_at, player_ids_json, state_json] = binds as [
+        string,
+        string,
+        number,
+        string,
+        string,
+      ];
+      tables.games.push({
+        id,
+        lobby_id,
+        status: "active",
+        started_at,
+        ended_at: null,
+        winner_id: null,
+        player_ids_json,
+        state_json,
+      });
       return { results: [], success: true };
+    }
+
+    // INSERT INTO game_log
+    if (trimmed.startsWith("INSERT INTO game_log")) {
+      const [id, game_id, payload_json, created_at] = binds as [
+        string,
+        string,
+        string,
+        number,
+      ];
+      tables.game_log.push({
+        id,
+        game_id,
+        round: 1,
+        player_id: null,
+        action_type: "game_started",
+        payload_json,
+        created_at,
+      });
+      return { results: [], success: true };
+    }
+
+    // UPDATE lobbies SET status = 'starting' WHERE id = ?
+    if (trimmed.startsWith("UPDATE lobbies SET status = 'in_game'")) {
+      const row = tables.lobbies.find((r) => r.id === binds[0]);
+      if (row) row.status = "in_game";
+      return { results: [], success: true };
+    }
+
+    // SELECT id, status, player_ids_json, started_at, ended_at, winner_id FROM games WHERE id = ?
+    if (trimmed.startsWith("SELECT id, status, player_ids_json, started_at, ended_at, winner_id FROM games WHERE id = ?")) {
+      const row = tables.games.find((r) => r.id === binds[0]) ?? null;
+      return { results: row ? [row] : [], first: row };
     }
 
     // UPDATE lobbies SET ... WHERE id = ? (settings update)
@@ -379,7 +429,7 @@ describe("POST /api/lobbies/:id/start", () => {
     expect(body.error).toContain("not_enough_players");
   });
 
-  it("transitions to starting with 2+ players", async () => {
+  it("creates game and transitions lobby to in_game with 2+ players", async () => {
     const db = createD1Stub();
     const createRes = await requestWithEnv("/api/lobbies", {
       method: "POST",
@@ -407,7 +457,17 @@ describe("POST /api/lobbies/:id/start", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.status).toBe("starting");
+    expect(body.status).toBe("in_game");
+    expect(typeof body.gameId).toBe("string");
+
+    const gameRes = await requestWithEnv(`/api/games/${body.gameId}`, {
+      method: "GET",
+      db,
+    });
+    expect(gameRes.status).toBe(200);
+    const game = await gameRes.json();
+    expect(game.status).toBe("active");
+    expect(game.playerCount).toBe(2);
   });
 });
 

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -185,7 +185,11 @@ const createD1Stub = () => {
     }
 
     // SELECT id, status, player_ids_json, started_at, ended_at, winner_id FROM games WHERE id = ?
-    if (trimmed.startsWith("SELECT id, status, player_ids_json, started_at, ended_at, winner_id FROM games WHERE id = ?")) {
+    if (
+      trimmed.startsWith(
+        "SELECT id, status, player_ids_json, started_at, ended_at, winner_id FROM games WHERE id = ?",
+      )
+    ) {
       const row = tables.games.find((r) => r.id === binds[0]) ?? null;
       return { results: row ? [row] : [], first: row };
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add full lobby onboarding UI at `/lobbies` to create lobby, join lobby (public or invite token), inspect selected lobby state, and start a game
- wire new web lobby API client functions and shared HTTP request helper usage for authenticated lobby endpoints
- update `POST /api/lobbies/:id/start` to create a persisted `games` row + initial `game_log` entry and transition lobby status to `in_game`
- extend integration coverage to assert start flow creates a game that is queryable from `/api/games/:id`
- fix CI lint failures by addressing React hook dependency lint in `LobbiesPage` and applying Biome formatting updates

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run test:integration`
- `pnpm run test:web`
- Manual browser verification for create -> join -> start -> games list (see walkthrough artifacts)

## Walkthrough artifacts
[lobby_create_join_start_flow.mp4](https://cursor.com/agents/bc-162343e9-5861-4f34-8fde-2c70ab26fef0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flobby_create_join_start_flow.mp4)

[Created lobby](https://cursor.com/agents/bc-162343e9-5861-4f34-8fde-2c70ab26fef0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flobby_created.webp)
[Started lobby status in_game](https://cursor.com/agents/bc-162343e9-5861-4f34-8fde-2c70ab26fef0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flobby_started_in_game.webp)
[Games list includes started game](https://cursor.com/agents/bc-162343e9-5861-4f34-8fde-2c70ab26fef0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgames_list_after_start.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-162343e9-5861-4f34-8fde-2c70ab26fef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-162343e9-5861-4f34-8fde-2c70ab26fef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

