### PR TITLE
docs: add non-obvious Cloud Agent caveats to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ Wrangler emulates D1, KV, and R2 locally via Miniflare — no Cloudflare account
 - Build `validation` and `shared` packages before running integration tests that import from them: `pnpm run --filter @oligopoly/validation build && pnpm run --filter @oligopoly/shared build`.
 - The worker exports a Hono `app` object as default; integration tests can call `app.request()` directly without running the server.
 - Cloudflare API credentials (account ID, API token) are **not required** for local development — Wrangler's local mode emulates all bindings.
+- You must create `.env` from `.env.example` (`cp .env.example .env`) before running dev servers. The defaults are sufficient for local dev.
+- D1 migrations (`pnpm run db:migrate:dev`) must be applied before the worker can serve lobby/game/auth requests. If you get `duplicate column name` errors, reset with `pnpm run db:reset:dev`.
+- Auth uses WebAuthn passkeys — there is no guest login. To test authenticated API endpoints, insert test users and sessions directly into D1 via `wrangler d1 execute`.
+- `pnpm run test:e2e` currently has no test files and exits with code 1 — this is expected and not a failure.
 
 ### Lint / Format / Typecheck / Test
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds practical Cloud Agent caveats discovered during environment setup to `AGENTS.md`:

- `.env` must be created from `.env.example` before running dev servers
- D1 migrations are required before the worker can serve lobby/game/auth requests
- WebAuthn passkeys only (no guest login); test authenticated endpoints via direct D1 inserts
- `test:e2e` has no test files yet and exits with code 1 (expected, not a failure)

These additions complement the existing instructions and help future agents avoid common setup pitfalls.

### Evidence of working environment

[Landing page](https://cursor.com/agents/bc-994073bd-a8b5-4274-b492-a45412540b9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_landing.png)
[Developer page showing live API data](https://cursor.com/agents/bc-994073bd-a8b5-4274-b492-a45412540b9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_developer_with_api.png)
[Lobbies page](https://cursor.com/agents/bc-994073bd-a8b5-4274-b492-a45412540b9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_lobbies.png)

API test log showing health check, auth session, lobby creation and listing:
[api_test_output.log](https://cursor.com/agents/bc-994073bd-a8b5-4274-b492-a45412540b9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_test_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-994073bd-a8b5-4274-b492-a45412540b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-994073bd-a8b5-4274-b492-a45412540b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

