### PR TITLE
feat: authoritative game actions (engine + POST /api/games/:id/actions)

### DIFF
--- a/oligopoly_technical_plan.md
+++ b/oligopoly_technical_plan.md
@@ -161,6 +161,7 @@ GET    /api/lobbies/:id/ws
 # Games
 GET    /api/games
 GET    /api/games/:id
+POST   /api/games/:id/actions   # authoritative game action: validates GameAction, applies @oligopoly/shared engine, persists state + log atomically (D1 batch)
 GET    /api/games/:id/state
 GET    /api/games/:id/log
 GET    /api/games/:id/replay
@@ -556,6 +557,12 @@ webauthn:challenge:login:{challenge}
 ```
 
 No deployment-specific delivery or session keys are defined in this plan.
+
+### Game engine and `games.state_json`
+
+- Persisted state is a superset of the public `GameState` contract: it may include **`affinityAssignments`** (server-only map). Per-player responses replace that map with **`myAffinityCardId`** (see `GET /api/games/:id/state`).
+- **`applyGameAction`** in `@oligopoly/shared` is the canonical deterministic transition `(state, action, actorCtx) → result`. Error keys live in **`GameEngineErrorKeys`** in `@oligopoly/validation`.
+- **`roll_dice`** payloads may omit **`result`** on the wire; the worker must attach an authoritative dice tuple (from secure RNG) before calling the reducer. Narrow tests may pass `result` when `rollDice` is omitted on the context.
 
 ---
 

--- a/packages/shared/src/engine/dice.ts
+++ b/packages/shared/src/engine/dice.ts
@@ -22,6 +22,19 @@ export const BOARD_SIZE = 40;
  * Note: Uses Math.random for local development.
  * Production server should replace with a seeded/deterministic RNG.
  */
+/** Uniform 1–6 via rejection sampling (256 is not divisible by 6). */
+export function rollFairD6(): number {
+  const bytes = new Uint8Array(1);
+  do {
+    crypto.getRandomValues(bytes);
+  } while (bytes[0] >= 252);
+  return (bytes[0] % 6) + 1;
+}
+
+export function rollFairDice(): [number, number] {
+  return [rollFairD6(), rollFairD6()];
+}
+
 export function rollDice(): [number, number] {
   const die1 = Math.floor(Math.random() * 6) + 1;
   const die2 = Math.floor(Math.random() * 6) + 1;

--- a/packages/shared/src/engine/gameReducer.ts
+++ b/packages/shared/src/engine/gameReducer.ts
@@ -1,0 +1,243 @@
+// ---------------------------------------------------------------------------
+// Authoritative game transitions: (persisted state, action, actor) → next state.
+//
+// Persistence notes (see worker GET /api/games/:id/state):
+// - `affinityAssignments` is server-only (full map). API responses replace it
+//   with `myAffinityCardId` per viewer.
+// - `state_json` is versioned implicitly by the engine; treat unknown fields as
+//   forward-compatible passthrough where possible.
+// ---------------------------------------------------------------------------
+
+import type { GameAction, GameState, PlayerState } from "@oligopoly/validation";
+import { GameEngineErrorKeys } from "@oligopoly/validation";
+import { isDoubles, moveOnPerimeter, TRIPLE_DOUBLES_LIMIT } from "./dice.js";
+import { ACTION_POINTS_PER_TURN, PASS_START_BONUS } from "./setup.js";
+
+/** Full row shape stored in `games.state_json` (superset of public `GameState`). */
+export type EngineGameState = GameState & {
+  affinityAssignments?: Record<string, string>;
+};
+
+export type ApplyGameActionContext = {
+  actorId: string;
+  /**
+   * Server must supply cryptographically sound dice. When absent (e.g. narrow
+   * unit tests), `roll_dice.result` on the action must be present.
+   */
+  rollDice?: () => [number, number];
+};
+
+export type ApplyGameActionSuccess = {
+  ok: true;
+  state: EngineGameState;
+  /** `game_log.action_type` */
+  logActionType: string;
+  logPayload: Record<string, unknown>;
+};
+
+export type ApplyGameActionFailure = {
+  ok: false;
+  errorKey: (typeof GameEngineErrorKeys)[keyof typeof GameEngineErrorKeys];
+};
+
+export type ApplyGameActionResult =
+  | ApplyGameActionSuccess
+  | ApplyGameActionFailure;
+
+function currentPlayerId(state: EngineGameState): string | undefined {
+  const order = state.turnOrder;
+  const idx = state.currentPlayerIndex;
+  if (!order?.length || idx === undefined || idx < 0 || idx >= order.length) {
+    return undefined;
+  }
+  return order[idx];
+}
+
+function playerById(
+  state: EngineGameState,
+  id: string,
+): PlayerState | undefined {
+  return state.players?.find((p) => p.playerId === id);
+}
+
+function cloneState(state: EngineGameState): EngineGameState {
+  return JSON.parse(JSON.stringify(state)) as EngineGameState;
+}
+
+function resolveDiceRoll(
+  action: Extract<GameAction, { type: "roll_dice" }>,
+  ctx: ApplyGameActionContext,
+): [number, number] | ApplyGameActionFailure {
+  if (ctx.rollDice) {
+    return ctx.rollDice();
+  }
+  if (action.result !== undefined) {
+    return action.result;
+  }
+  return {
+    ok: false,
+    errorKey: GameEngineErrorKeys.DICE_RESULT_REQUIRED,
+  };
+}
+
+function applyRollDice(
+  state: EngineGameState,
+  action: Extract<GameAction, { type: "roll_dice" }>,
+  ctx: ApplyGameActionContext,
+): ApplyGameActionResult {
+  const expected = currentPlayerId(state);
+  if (!expected || expected !== ctx.actorId) {
+    return { ok: false, errorKey: GameEngineErrorKeys.NOT_YOUR_TURN };
+  }
+
+  const phase = state.phase ?? "action";
+  if (phase !== "action" && phase !== "market_event") {
+    return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PHASE };
+  }
+
+  const me = playerById(state, ctx.actorId);
+  if (!me) {
+    return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
+  }
+
+  if (me.actionPointsRemaining !== 0) {
+    return { ok: false, errorKey: GameEngineErrorKeys.DICE_ALREADY_ROLLED };
+  }
+
+  const rollOutcome = resolveDiceRoll(action, ctx);
+  if ("ok" in rollOutcome) {
+    return rollOutcome;
+  }
+  const roll = rollOutcome;
+
+  if (typeof me.position !== "number") {
+    return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
+  }
+  const startPosition = me.position;
+
+  const next = cloneState(state);
+  next.phase = "action";
+
+  const players = next.players;
+  if (!players) {
+    return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
+  }
+
+  const idx = players.findIndex((p) => p.playerId === ctx.actorId);
+  if (idx < 0) {
+    return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
+  }
+
+  const p = { ...players[idx] } as PlayerState;
+  const total = roll[0] + roll[1];
+  const { newPosition, passedStart } = moveOnPerimeter(startPosition, total);
+  p.position = newPosition;
+  if (passedStart) {
+    p.capital += PASS_START_BONUS;
+  }
+
+  let doublesCount = p.doublesCount;
+  if (isDoubles(roll)) {
+    doublesCount += 1;
+    if (doublesCount >= TRIPLE_DOUBLES_LIMIT) {
+      p.inRegulation = true;
+      doublesCount = 0;
+    }
+  } else {
+    doublesCount = 0;
+  }
+  p.doublesCount = doublesCount;
+  p.actionPointsRemaining = ACTION_POINTS_PER_TURN;
+
+  players[idx] = p;
+  next.players = players;
+
+  return {
+    ok: true,
+    state: next,
+    logActionType: "roll_dice",
+    logPayload: { roll, newPosition, passedStart },
+  };
+}
+
+function applyEndTurn(
+  state: EngineGameState,
+  _action: Extract<GameAction, { type: "end_turn" }>,
+  ctx: ApplyGameActionContext,
+): ApplyGameActionResult {
+  const expected = currentPlayerId(state);
+  if (!expected || expected !== ctx.actorId) {
+    return { ok: false, errorKey: GameEngineErrorKeys.NOT_YOUR_TURN };
+  }
+
+  const order = state.turnOrder;
+  const curIdx = state.currentPlayerIndex;
+  if (
+    !order?.length ||
+    curIdx === undefined ||
+    curIdx < 0 ||
+    curIdx >= order.length
+  ) {
+    return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
+  }
+
+  const next = cloneState(state);
+  const players = next.players?.map((pl) =>
+    pl.playerId === ctx.actorId ? { ...pl, actionPointsRemaining: 0 } : pl,
+  );
+  next.players = players;
+
+  const followingIndex = (curIdx + 1) % order.length;
+  next.currentPlayerIndex = followingIndex;
+  if (followingIndex === 0) {
+    next.round = (next.round ?? 1) + 1;
+  }
+
+  return {
+    ok: true,
+    state: next,
+    logActionType: "end_turn",
+    logPayload: {
+      previousPlayerIndex: curIdx,
+      nextPlayerIndex: followingIndex,
+    },
+  };
+}
+
+/**
+ * Pure transition used by the worker after authZ. Mutates nothing; returns a
+ * deep-cloned next state on success.
+ */
+export function applyGameAction(
+  state: EngineGameState,
+  action: GameAction,
+  ctx: ApplyGameActionContext,
+): ApplyGameActionResult {
+  switch (action.type) {
+    case "roll_dice":
+      return applyRollDice(state, action, ctx);
+    case "end_turn":
+      return applyEndTurn(state, action, ctx);
+    case "buy_tile":
+    case "decline_tile":
+    case "develop_tile":
+    case "mortgage_tile":
+    case "redeem_tile":
+    case "auction_bid":
+    case "start_negotiation":
+    case "sign_contract":
+    case "sign_handshake":
+    case "break_handshake":
+    case "form_syndicate":
+    case "call_vote":
+    case "path_choice":
+      return {
+        ok: false,
+        errorKey: GameEngineErrorKeys.ACTION_NOT_IMPLEMENTED,
+      };
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/shared/src/engine/gameReducer.ts
+++ b/packages/shared/src/engine/gameReducer.ts
@@ -16,6 +16,8 @@ import { ACTION_POINTS_PER_TURN, PASS_START_BONUS } from "./setup.js";
 /** Full row shape stored in `games.state_json` (superset of public `GameState`). */
 export type EngineGameState = GameState & {
   affinityAssignments?: Record<string, string>;
+  /** Set after a roll this turn; cleared on end_turn (mirrors gameStateMachine). */
+  lastDiceRoll?: [number, number] | null;
 };
 
 export type ApplyGameActionContext = {
@@ -91,7 +93,11 @@ function applyRollDice(
   }
 
   const phase = state.phase ?? "action";
-  if (phase !== "action" && phase !== "market_event") {
+  if (
+    phase !== "action" &&
+    phase !== "market_event" &&
+    phase !== "rolling_doubles"
+  ) {
     return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PHASE };
   }
 
@@ -100,7 +106,14 @@ function applyRollDice(
     return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
   }
 
-  if (me.actionPointsRemaining !== 0) {
+  const mayRerollDoubles =
+    state.lastDiceRoll !== undefined &&
+    state.lastDiceRoll !== null &&
+    isDoubles(state.lastDiceRoll) &&
+    me.doublesCount > 0 &&
+    me.doublesCount < TRIPLE_DOUBLES_LIMIT;
+
+  if (me.actionPointsRemaining !== 0 && !mayRerollDoubles) {
     return { ok: false, errorKey: GameEngineErrorKeys.DICE_ALREADY_ROLLED };
   }
 
@@ -116,7 +129,6 @@ function applyRollDice(
   const startPosition = me.position;
 
   const next = cloneState(state);
-  next.phase = "action";
 
   const players = next.players;
   if (!players) {
@@ -151,6 +163,17 @@ function applyRollDice(
 
   players[idx] = p;
   next.players = players;
+  next.lastDiceRoll = roll;
+
+  if (
+    isDoubles(roll) &&
+    doublesCount > 0 &&
+    doublesCount < TRIPLE_DOUBLES_LIMIT
+  ) {
+    next.phase = "rolling_doubles";
+  } else {
+    next.phase = "action";
+  }
 
   return {
     ok: true,
@@ -181,11 +204,20 @@ function applyEndTurn(
     return { ok: false, errorKey: GameEngineErrorKeys.INVALID_PLAYER_STATE };
   }
 
+  const phase = state.phase ?? "action";
+  if (phase !== "action" || !state.lastDiceRoll) {
+    return { ok: false, errorKey: GameEngineErrorKeys.CANNOT_END_TURN };
+  }
+
   const next = cloneState(state);
   const players = next.players?.map((pl) =>
-    pl.playerId === ctx.actorId ? { ...pl, actionPointsRemaining: 0 } : pl,
+    pl.playerId === ctx.actorId
+      ? { ...pl, actionPointsRemaining: 0, doublesCount: 0 }
+      : pl,
   );
   next.players = players;
+  next.lastDiceRoll = null;
+  next.phase = "market_event";
 
   const followingIndex = (curIdx + 1) % order.length;
   next.currentPlayerIndex = followingIndex;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -136,6 +136,14 @@ export {
   rollPathChoiceDie,
   TRIPLE_DOUBLES_LIMIT,
 } from "./engine/dice.js";
+export type {
+  ApplyGameActionContext,
+  ApplyGameActionFailure,
+  ApplyGameActionResult,
+  ApplyGameActionSuccess,
+  EngineGameState,
+} from "./engine/gameReducer.js";
+export { applyGameAction } from "./engine/gameReducer.js";
 export {
   calculateAbsorptionPrice,
   calculateMortgageValue,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -133,6 +133,8 @@ export {
   isPerimeterChoice,
   moveOnPerimeter,
   rollDice,
+  rollFairD6,
+  rollFairDice,
   rollPathChoiceDie,
   TRIPLE_DOUBLES_LIMIT,
 } from "./engine/dice.js";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2022", "WebWorker"]
   },
   "include": ["src"],
   "references": [{ "path": "../validation" }]

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -50,6 +50,7 @@ export const GameEngineErrorKeys = {
   DICE_RESULT_REQUIRED: "game.dice_result_required",
   INVALID_PLAYER_STATE: "game.invalid_player_state",
   ACTION_NOT_IMPLEMENTED: "game.action_not_implemented",
+  CANNOT_END_TURN: "game.cannot_end_turn",
 } as const;
 
 export const HealthResponseSchema = z.object({

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -42,6 +42,16 @@ export const NegotiationErrorKeys = {
     "negotiation.syndicate_dissolution_requires_unanimous_vote",
 } as const;
 
+/** Stable keys returned by `applyGameAction` in `@oligopoly/shared` */
+export const GameEngineErrorKeys = {
+  NOT_YOUR_TURN: "game.not_your_turn",
+  INVALID_PHASE: "game.invalid_phase",
+  DICE_ALREADY_ROLLED: "game.dice_already_rolled",
+  DICE_RESULT_REQUIRED: "game.dice_result_required",
+  INVALID_PLAYER_STATE: "game.invalid_player_state",
+  ACTION_NOT_IMPLEMENTED: "game.action_not_implemented",
+} as const;
+
 export const HealthResponseSchema = z.object({
   status: z.literal("ok"),
   timestamp: z.number(),
@@ -437,10 +447,10 @@ export type UpdateLobbySettingsInput = z.infer<
 export const GameActionSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("roll_dice"),
-    result: z.tuple([
-      z.number().int().min(1).max(6),
-      z.number().int().min(1).max(6),
-    ]),
+    /** Omitted on client requests; server fills from authoritative RNG before persistence. */
+    result: z
+      .tuple([z.number().int().min(1).max(6), z.number().int().min(1).max(6)])
+      .optional(),
   }),
   z.object({
     type: z.literal("buy_tile"),

--- a/packages/worker/src/gameStateView.ts
+++ b/packages/worker/src/gameStateView.ts
@@ -1,0 +1,30 @@
+import type { GameState } from "@oligopoly/validation";
+
+/** Persisted `state_json` may include server-only affinity assignments. */
+export type PersistedGameState = GameState & {
+  affinityAssignments?: Record<string, string>;
+  settings?: { spectatorMode?: string; [key: string]: unknown };
+};
+
+/**
+ * Strip hidden affinity data for HTTP responses.
+ * Callers must enforce authZ (player vs spectator) before using this.
+ */
+export function toClientGameState(
+  state: PersistedGameState,
+  mode: "spectator" | "player",
+  playerId: string,
+): Record<string, unknown> {
+  if (mode === "spectator") {
+    const { affinityAssignments: _a, ...rest } = state;
+    return rest as Record<string, unknown>;
+  }
+
+  if (state.affinityAssignments) {
+    const myAffinity = state.affinityAssignments[playerId] ?? null;
+    const { affinityAssignments: _all, ...rest } = state;
+    return { ...rest, myAffinityCardId: myAffinity } as Record<string, unknown>;
+  }
+
+  return state as Record<string, unknown>;
+}

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -1,10 +1,12 @@
-import type {
-  GameLogEntry,
-  GameState,
-  GameSummary,
-} from "@oligopoly/validation";
-import { GameStatusSchema } from "@oligopoly/validation";
+import { zValidator } from "@hono/zod-validator";
+import { applyGameAction, type EngineGameState } from "@oligopoly/shared";
+import type { GameLogEntry, GameSummary } from "@oligopoly/validation";
+import { GameActionSchema, GameStatusSchema } from "@oligopoly/validation";
 import { Hono } from "hono";
+import {
+  type PersistedGameState,
+  toClientGameState,
+} from "../gameStateView.js";
 
 type Bindings = {
   ALLOWED_ORIGINS?: string;
@@ -133,6 +135,99 @@ gameRoutes.get("/:id", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /api/games/:id/actions
+// Authoritative game transition: validate GameAction, apply engine, persist.
+// ---------------------------------------------------------------------------
+gameRoutes.post(
+  "/:id/actions",
+  zValidator("json", GameActionSchema),
+  async (c) => {
+    const id = c.req.param("id");
+    const subject = c.get("userId");
+
+    if (!subject) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const db = c.env?.DB;
+    if (!db) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    const row = await db
+      .prepare(
+        "SELECT id, status, player_ids_json, state_json FROM games WHERE id = ?",
+      )
+      .bind(id)
+      .first<{
+        id: string;
+        status: string;
+        player_ids_json: string;
+        state_json: string | null;
+      }>();
+
+    if (!row) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    if (row.status !== "active") {
+      return c.json({ error: "Game is not active" }, 409);
+    }
+
+    const playerIds = JSON.parse(row.player_ids_json) as string[];
+    if (!playerIds.includes(subject)) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+
+    const persisted: EngineGameState = row.state_json
+      ? (JSON.parse(row.state_json) as EngineGameState)
+      : { gameId: id, round: 0 };
+
+    const action = c.req.valid("json");
+    const outcome = applyGameAction(persisted, action, {
+      actorId: subject,
+      rollDice: rollSecureDice,
+    });
+
+    if (!outcome.ok) {
+      return c.json({ error: outcome.errorKey }, 400);
+    }
+
+    const logId = crypto.randomUUID();
+    const now = Date.now();
+    const round = outcome.state.round ?? 1;
+
+    await db.batch([
+      db
+        .prepare("UPDATE games SET state_json = ? WHERE id = ?")
+        .bind(JSON.stringify(outcome.state), id),
+      db
+        .prepare(
+          `INSERT INTO game_log (id, game_id, round, player_id, action_type, payload_json, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          logId,
+          id,
+          round,
+          subject,
+          outcome.logActionType,
+          JSON.stringify(outcome.logPayload),
+          now,
+        ),
+    ]);
+
+    const clientState = toClientGameState(
+      outcome.state as PersistedGameState,
+      "player",
+      subject,
+    );
+
+    return c.json({ state: clientState });
+  },
+);
+
+// ---------------------------------------------------------------------------
 // GET /api/games/:id/state
 // Returns the current game state snapshot.
 // Auth required (user must be a player or spectator).
@@ -164,18 +259,13 @@ gameRoutes.get("/:id/state", async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
-  type StateWithAffinity = GameState & {
-    affinityAssignments?: Record<string, string>;
-    settings?: { spectatorMode?: string; [key: string]: unknown };
-  };
-
   const playerIds = JSON.parse(row.player_ids_json) as string[];
   const isPlayer = playerIds.includes(subject);
 
   // If not a player, check whether spectator mode is enabled
   if (!isPlayer) {
-    const state: StateWithAffinity = row.state_json
-      ? (JSON.parse(row.state_json) as StateWithAffinity)
+    const state: PersistedGameState = row.state_json
+      ? (JSON.parse(row.state_json) as PersistedGameState)
       : { gameId: id, round: 0 };
 
     const spectatorEnabled = state.settings?.spectatorMode === "enabled";
@@ -183,25 +273,14 @@ gameRoutes.get("/:id/state", async (c) => {
       return c.json({ error: "Forbidden" }, 403);
     }
 
-    // Spectators see board state but never see affinity assignments
-    const { affinityAssignments: _hidden, ...spectatorState } = state;
-    return c.json(spectatorState);
+    return c.json(toClientGameState(state, "spectator", subject));
   }
 
-  const state: StateWithAffinity = row.state_json
-    ? (JSON.parse(row.state_json) as StateWithAffinity)
+  const state: PersistedGameState = row.state_json
+    ? (JSON.parse(row.state_json) as PersistedGameState)
     : { gameId: id, round: 0 };
 
-  // Redact hidden information: each player may only see their own affinity card.
-  // Replace the full affinityAssignments map with only the requesting player's card.
-  if (state.affinityAssignments) {
-    const myAffinity = state.affinityAssignments[subject] ?? null;
-    // Remove the full map and expose only the requester's card
-    const { affinityAssignments: _all, ...rest } = state;
-    return c.json({ ...rest, myAffinityCardId: myAffinity });
-  }
-
-  return c.json(state);
+  return c.json(toClientGameState(state, "player", subject));
 });
 
 // ---------------------------------------------------------------------------
@@ -345,3 +424,9 @@ gameRoutes.get("/:id/ws", (c) => {
 gameRoutes.get("/:id/spectate", (c) => {
   return c.json({ error: "WebSocket support not yet implemented" }, 501);
 });
+
+function rollSecureDice(): [number, number] {
+  const u = new Uint8Array(2);
+  crypto.getRandomValues(u);
+  return [(u[0] % 6) + 1, (u[1] % 6) + 1];
+}

--- a/tests/integration/games.test.ts
+++ b/tests/integration/games.test.ts
@@ -1,3 +1,4 @@
+import { GameEngineErrorKeys } from "@oligopoly/validation";
 import app from "@oligopoly/worker";
 import { describe, expect, it } from "vitest";
 
@@ -21,16 +22,75 @@ function makeDb(tables: Record<string, Row[]>) {
       const filtered = applyWhere(rows, query, boundParams);
       return { results: filtered as T[] };
     },
+    async run(): Promise<{ success: boolean }> {
+      applyMutation(query, boundParams, tables);
+      return { success: true };
+    },
   });
 
   return {
     prepare: (query: string) => makeStmt(query, []),
+    batch: async (stmts: Array<{ run: () => Promise<unknown> }>) => {
+      const out: unknown[] = [];
+      for (const s of stmts) {
+        out.push(await s.run());
+      }
+      return out;
+    },
   };
 }
 
 function inferTable(query: string): string {
-  const match = query.match(/FROM\s+(\w+)/i);
-  return match?.[1] ?? "";
+  const from = query.match(/FROM\s+(\w+)/i);
+  if (from) {
+    return from[1];
+  }
+  const upd = query.match(/UPDATE\s+(\w+)/i);
+  if (upd) {
+    return upd[1];
+  }
+  const ins = query.match(/INTO\s+(\w+)/i);
+  if (ins) {
+    return ins[1];
+  }
+  return "";
+}
+
+function applyMutation(
+  query: string,
+  params: unknown[],
+  tables: Record<string, Row[]>,
+) {
+  if (/UPDATE\s+games/i.test(query) && /state_json/i.test(query)) {
+    const stateJson = params[0];
+    const id = params[1];
+    const row = tables.games?.find((r) => r.id === id);
+    if (row) {
+      row.state_json = stateJson;
+    }
+    return;
+  }
+
+  if (/INSERT\s+INTO\s+game_log/i.test(query)) {
+    const [
+      id,
+      game_id,
+      round,
+      player_id,
+      action_type,
+      payload_json,
+      created_at,
+    ] = params;
+    tables.game_log.push({
+      id,
+      game_id,
+      round,
+      player_id,
+      action_type,
+      payload_json,
+      created_at,
+    });
+  }
 }
 
 function applyWhere(rows: Row[], query: string, params: unknown[]): Row[] {
@@ -44,6 +104,11 @@ function applyWhere(rows: Row[], query: string, params: unknown[]): Row[] {
   const statusMatch = query.match(/WHERE\s+status\s*=\s*\?/i);
   if (statusMatch && params.length > 0) {
     return rows.filter((r) => r.status === params[0]);
+  }
+
+  const gameIdMatch = query.match(/WHERE\s+game_id\s*=\s*\?/i);
+  if (gameIdMatch && params.length > 0) {
+    return rows.filter((r) => r.game_id === params[0]);
   }
 
   return rows;
@@ -74,6 +139,57 @@ const completedGame: Row = {
   winner_id: PLAYER_A,
   state_json: null,
 };
+
+const playableGameTemplate: Row = {
+  id: "game-playable",
+  status: "active",
+  player_ids_json: JSON.stringify([PLAYER_A, PLAYER_B]),
+  started_at: 2000,
+  ended_at: null,
+  winner_id: null,
+  state_json: JSON.stringify({
+    gameId: "game-playable",
+    round: 1,
+    phase: "market_event",
+    currentPlayerIndex: 0,
+    turnOrder: [PLAYER_A, PLAYER_B],
+    freeMarketPool: 0,
+    affinityAssignments: { [PLAYER_A]: "aff-a", [PLAYER_B]: "aff-b" },
+    players: [
+      {
+        playerId: PLAYER_A,
+        position: 0,
+        capital: 1500,
+        ownedTilePositions: [],
+        mortgagedTilePositions: [],
+        developmentTokens: {},
+        trustworthiness: 7,
+        actionPointsRemaining: 0,
+        inRegulation: false,
+        doublesCount: 0,
+        isOnDiagonal: false,
+      },
+      {
+        playerId: PLAYER_B,
+        position: 0,
+        capital: 1500,
+        ownedTilePositions: [],
+        mortgagedTilePositions: [],
+        developmentTokens: {},
+        trustworthiness: 7,
+        actionPointsRemaining: 0,
+        inRegulation: false,
+        doublesCount: 0,
+        isOnDiagonal: false,
+      },
+    ],
+    settings: { spectatorMode: "disabled" },
+  }),
+};
+
+function cloneRow<T extends Row>(r: T): T {
+  return JSON.parse(JSON.stringify(r)) as T;
+}
 
 const logEntry: Row = {
   id: "log-1",
@@ -116,9 +232,13 @@ const outsiderUser: Row = {
 function makeEnv(extraTables: Record<string, Row[]> = {}) {
   return {
     DB: makeDb({
-      users: [userA, userB, outsiderUser],
-      games: [activeGame, completedGame],
-      game_log: [logEntry, logEntryCompleted],
+      users: [cloneRow(userA), cloneRow(userB), cloneRow(outsiderUser)],
+      games: [
+        cloneRow(activeGame),
+        cloneRow(completedGame),
+        cloneRow(playableGameTemplate),
+      ],
+      game_log: [cloneRow(logEntry), cloneRow(logEntryCompleted)],
       ...extraTables,
     }),
   };
@@ -264,6 +384,100 @@ describe("GET /api/games/:id/replay", () => {
     expect(res.status).toBe(200);
     const body = await res.json<{ replay: unknown[] }>();
     expect(Array.isArray(body.replay)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/games/:id/actions
+// ---------------------------------------------------------------------------
+describe("POST /api/games/:id/actions", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request(
+      "/api/games/game-playable/actions",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "roll_dice" }),
+      },
+      makeEnv(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-participant", async () => {
+    const res = await app.request(
+      "/api/games/game-playable/actions",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-subject": "outsider",
+        },
+        body: JSON.stringify({ type: "roll_dice" }),
+      },
+      makeEnv(),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for unimplemented actions", async () => {
+    const res = await app.request(
+      "/api/games/game-playable/actions",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-subject": PLAYER_A,
+        },
+        body: JSON.stringify({ type: "buy_tile", tilePosition: 1 }),
+      },
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe(GameEngineErrorKeys.ACTION_NOT_IMPLEMENTED);
+  });
+
+  it("applies roll_dice, persists state, and redacts affinity in the response", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/api/games/game-playable/actions",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-subject": PLAYER_A,
+        },
+        body: JSON.stringify({ type: "roll_dice" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      state: {
+        phase: string;
+        myAffinityCardId?: string | null;
+        affinityAssignments?: Record<string, string>;
+        players?: { position: number }[];
+      };
+    }>();
+    expect(body.state.phase).toBe("action");
+    expect(body.state.myAffinityCardId).toBe("aff-a");
+    expect(body.state.affinityAssignments).toBeUndefined();
+    expect(body.state.players?.[0]?.position).not.toBe(0);
+
+    const logRes = await app.request(
+      "/api/games/game-playable/log",
+      { headers: { "x-subject": PLAYER_A } },
+      env,
+    );
+    expect(logRes.status).toBe(200);
+    const logJson = await logRes.json<{
+      log: { actionType: string; playerId: string | null }[];
+    }>();
+    const last = logJson.log.at(-1);
+    expect(last?.actionType).toBe("roll_dice");
+    expect(last?.playerId).toBe(PLAYER_A);
   });
 });
 

--- a/tests/unit/gameReducer.test.ts
+++ b/tests/unit/gameReducer.test.ts
@@ -1,0 +1,165 @@
+import { applyGameAction, type EngineGameState } from "@oligopoly/shared";
+import { GameEngineErrorKeys } from "@oligopoly/validation";
+import { describe, expect, it } from "vitest";
+
+function minimalTwoPlayerState(
+  phase: "market_event" | "action",
+): EngineGameState {
+  return {
+    gameId: "g1",
+    round: 1,
+    phase,
+    currentPlayerIndex: 0,
+    turnOrder: ["alice", "bob"],
+    freeMarketPool: 0,
+    players: [
+      {
+        playerId: "alice",
+        position: 0,
+        capital: 1500,
+        ownedTilePositions: [],
+        mortgagedTilePositions: [],
+        developmentTokens: {},
+        trustworthiness: 7,
+        actionPointsRemaining: 0,
+        inRegulation: false,
+        doublesCount: 0,
+        isOnDiagonal: false,
+      },
+      {
+        playerId: "bob",
+        position: 0,
+        capital: 1500,
+        ownedTilePositions: [],
+        mortgagedTilePositions: [],
+        developmentTokens: {},
+        trustworthiness: 7,
+        actionPointsRemaining: 0,
+        inRegulation: false,
+        doublesCount: 0,
+        isOnDiagonal: false,
+      },
+    ],
+    settings: {},
+  };
+}
+
+describe("applyGameAction", () => {
+  it("rejects roll_dice when it is not the actor's turn", () => {
+    const state = minimalTwoPlayerState("action");
+    const r = applyGameAction(state, { type: "roll_dice" }, { actorId: "bob" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errorKey).toBe(GameEngineErrorKeys.NOT_YOUR_TURN);
+    }
+  });
+
+  it("rolls from market_event using ctx.rollDice and moves on the perimeter", () => {
+    const state = minimalTwoPlayerState("market_event");
+    const r = applyGameAction(
+      state,
+      { type: "roll_dice" },
+      { actorId: "alice", rollDice: () => [2, 3] },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      return;
+    }
+    expect(r.state.phase).toBe("action");
+    expect(r.state.players?.[0]?.position).toBe(5);
+    expect(r.state.players?.[0]?.actionPointsRemaining).toBe(2);
+    expect(r.logActionType).toBe("roll_dice");
+  });
+
+  it("uses action.result when rollDice is omitted (tests only)", () => {
+    const state = minimalTwoPlayerState("action");
+    const r = applyGameAction(
+      state,
+      { type: "roll_dice", result: [1, 1] },
+      { actorId: "alice" },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      return;
+    }
+    expect(r.state.players?.[0]?.position).toBe(2);
+    expect(r.state.players?.[0]?.doublesCount).toBe(1);
+  });
+
+  it("returns DICE_RESULT_REQUIRED when neither rollDice nor result is set", () => {
+    const state = minimalTwoPlayerState("action");
+    const r = applyGameAction(
+      state,
+      { type: "roll_dice" },
+      { actorId: "alice" },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errorKey).toBe(GameEngineErrorKeys.DICE_RESULT_REQUIRED);
+    }
+  });
+
+  it("advances turn on end_turn and increments round after a full cycle", () => {
+    const state = minimalTwoPlayerState("action");
+    const rolled = applyGameAction(
+      state,
+      { type: "roll_dice", result: [1, 1] },
+      { actorId: "alice" },
+    );
+    expect(rolled.ok).toBe(true);
+    if (!rolled.ok) {
+      return;
+    }
+
+    const e1 = applyGameAction(
+      rolled.state,
+      { type: "end_turn" },
+      {
+        actorId: "alice",
+      },
+    );
+    expect(e1.ok).toBe(true);
+    if (!e1.ok) {
+      return;
+    }
+    expect(e1.state.currentPlayerIndex).toBe(1);
+    expect(e1.state.round).toBe(1);
+
+    const bobRoll = applyGameAction(
+      e1.state,
+      { type: "roll_dice", result: [2, 2] },
+      { actorId: "bob" },
+    );
+    expect(bobRoll.ok).toBe(true);
+    if (!bobRoll.ok) {
+      return;
+    }
+
+    const e2 = applyGameAction(
+      bobRoll.state,
+      { type: "end_turn" },
+      {
+        actorId: "bob",
+      },
+    );
+    expect(e2.ok).toBe(true);
+    if (!e2.ok) {
+      return;
+    }
+    expect(e2.state.currentPlayerIndex).toBe(0);
+    expect(e2.state.round).toBe(2);
+  });
+
+  it("returns ACTION_NOT_IMPLEMENTED for buy_tile", () => {
+    const state = minimalTwoPlayerState("action");
+    const r = applyGameAction(
+      state,
+      { type: "buy_tile", tilePosition: 1 },
+      { actorId: "alice" },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errorKey).toBe(GameEngineErrorKeys.ACTION_NOT_IMPLEMENTED);
+    }
+  });
+});

--- a/tests/unit/gameReducer.test.ts
+++ b/tests/unit/gameReducer.test.ts
@@ -100,10 +100,10 @@ describe("applyGameAction", () => {
   });
 
   it("advances turn on end_turn and increments round after a full cycle", () => {
-    const state = minimalTwoPlayerState("action");
+    const state = minimalTwoPlayerState("market_event");
     const rolled = applyGameAction(
       state,
-      { type: "roll_dice", result: [1, 1] },
+      { type: "roll_dice", result: [2, 3] },
       { actorId: "alice" },
     );
     expect(rolled.ok).toBe(true);
@@ -127,7 +127,7 @@ describe("applyGameAction", () => {
 
     const bobRoll = applyGameAction(
       e1.state,
-      { type: "roll_dice", result: [2, 2] },
+      { type: "roll_dice", result: [1, 2] },
       { actorId: "bob" },
     );
     expect(bobRoll.ok).toBe(true);
@@ -148,6 +148,46 @@ describe("applyGameAction", () => {
     }
     expect(e2.state.currentPlayerIndex).toBe(0);
     expect(e2.state.round).toBe(2);
+  });
+
+  it("rejects end_turn before rolling", () => {
+    const state = minimalTwoPlayerState("market_event");
+    const r = applyGameAction(
+      state,
+      { type: "end_turn" },
+      { actorId: "alice" },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errorKey).toBe(GameEngineErrorKeys.CANNOT_END_TURN);
+    }
+  });
+
+  it("allows a second roll_dice after doubles", () => {
+    const state = minimalTwoPlayerState("market_event");
+    const first = applyGameAction(
+      state,
+      { type: "roll_dice", result: [4, 4] },
+      { actorId: "alice" },
+    );
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+    expect(first.state.phase).toBe("rolling_doubles");
+    expect(first.state.players?.[0]?.doublesCount).toBe(1);
+
+    const second = applyGameAction(
+      first.state,
+      { type: "roll_dice", result: [2, 3] },
+      { actorId: "alice" },
+    );
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      return;
+    }
+    expect(second.state.players?.[0]?.doublesCount).toBe(0);
+    expect(second.state.phase).toBe("action");
   });
 
   it("returns ACTION_NOT_IMPLEMENTED for buy_tile", () => {

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -712,6 +712,11 @@ describe("GameActionSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts roll_dice without result (server fills authoritative dice)", () => {
+    const result = GameActionSchema.safeParse({ type: "roll_dice" });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts buy_tile action with number position", () => {
     const result = GameActionSchema.safeParse({
       type: "buy_tile",


### PR DESCRIPTION
## Summary
- Adds `applyGameAction` in `@oligopoly/shared` for `roll_dice` and `end_turn`, with `GameEngineErrorKeys` and optional `roll_dice.result` on the wire (server fills dice).
- Implements `POST /api/games/:id/actions` with D1 `batch` for state + log; centralizes affinity redaction in `gameStateView.ts` and reuses it from `GET /api/games/:id/state`.
- Updates `oligopoly_technical_plan.md` (route + persisted state notes) and adds unit/integration coverage.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix` / `pnpm run lint`
- [x] `pnpm run test:unit`
- [x] `pnpm run test:integration`

Made with [Cursor](https://cursor.com)