### PR TITLE
Sealed auction bid-window timers and GameRoom orchestration

### DIFF
--- a/oligopoly_technical_plan.md
+++ b/oligopoly_technical_plan.md
@@ -601,7 +601,8 @@ No deployment-specific delivery or session keys are defined in this plan.
 - **Declined tile purchase** enters **`waiting_for_auction_bids`** with **`pendingAuction`** (sealed bids only in this slice). All non-eliminated players in turn order are eligible; **`auction_bid`** / **`auction_pass`** bypass the current-turn check. The auction auto-settles when every eligible player has submitted; highest bid wins, ties trigger additional sealed rounds with **`tieBreakMinBid`**, and all-pass leaves the tile unowned. **`resumePhase`** restores **`action`** or **`rolling_doubles`** when the decline happened during a doubles chain.
 - Sealed bid amounts are redacted in HTTP/WS player views (`toClientGameState`) and stripped from broadcast snapshots (`publicStateForBroadcast`); only the viewer's own **`mySubmission`** is returned until settlement reveals all bids in the action log.
 - Per-player **`auction_bid`** log entries omit bid amounts until **`auction_settled`** reveals all submissions simultaneously.
-- **`GameRoom`** AI loop uses **`findNextAiAuctionActor`** / **`chooseAiActionForPlayer`** to submit bids for AI seats without a submission. Auction bid-window timers are deferred; settlement is submission-driven for now.
+- **`GameRoom`** AI loop uses **`findNextAiAuctionActor`** / **`chooseAiActionForPlayer`** to submit bids for AI seats without a submission. **`GameRoom.syncAfterStateChange`** runs the AI loop during **`waiting_for_auction_bids`** whenever an AI seat still owes a submission, not only on the current turn actor.
+- Sealed auctions honor **`settings.auctionBidWindow`**: **`pendingAuction.bidDeadlineAt`** is set at decline/tie-break start; **`closeAuctionBidWindowIfReady`** auto-passes missing bidders and settles when the deadline passes (or immediately when all eligible players submit). **`GameRoom`** alarms on the bid deadline via **`syncGameRoomTimer`**. Auction settle delay remains deferred.
 
 ---
 

--- a/packages/shared/src/engine/auction.ts
+++ b/packages/shared/src/engine/auction.ts
@@ -1,4 +1,8 @@
 import { getTileByPosition } from "../config/board.js";
+import {
+  computeAuctionBidDeadline,
+  isAuctionBidWindowOpen,
+} from "./auctionTiming.js";
 import { rollFairD6 } from "./dice.js";
 import type {
   ApplyActionResult,
@@ -16,6 +20,7 @@ export type PendingAuctionState = {
   tieBreakMinBid?: number;
   tieBreakRound: number;
   resumePhase: "action" | "rolling_doubles";
+  bidDeadlineAt: number;
 };
 
 function deepClone<T>(obj: T): T {
@@ -27,6 +32,10 @@ function getPlayer(
   playerId: string,
 ): InternalPlayerState | undefined {
   return state.players.find((player) => player.playerId === playerId);
+}
+
+function auctionBidDeadline(state: InternalGameState, nowMs: number): number {
+  return computeAuctionBidDeadline(nowMs, state.settings);
 }
 
 export function getActiveEligibleBidders(state: InternalGameState): string[] {
@@ -56,6 +65,7 @@ export function startDeclineAuction(
   state: InternalGameState,
   tilePosition: number | string,
   resumePhase: "action" | "rolling_doubles",
+  nowMs: number = Date.now(),
 ): InternalGameState {
   const eligiblePlayerIds = state.turnOrder.filter(
     (playerId) => !state.eliminatedPlayerIds.includes(playerId),
@@ -73,6 +83,7 @@ export function startDeclineAuction(
       eligiblePlayerIds,
       tieBreakRound: 0,
       resumePhase,
+      bidDeadlineAt: auctionBidDeadline(state, nowMs),
     },
   };
 }
@@ -149,8 +160,39 @@ function awardTileToWinner(
   return { state: newState, logEntries: logs };
 }
 
+function startTieBreakRound(
+  state: InternalGameState,
+  topBidders: string[],
+  maxAmount: number,
+  nowMs: number,
+  logs: LogEntry[],
+): ApplyActionResult {
+  const auction = state.pendingAuction!;
+  const newState = deepClone(state);
+  newState.pendingAuction = {
+    ...auction,
+    submissions: {},
+    eligiblePlayerIds: topBidders,
+    tieBreakMinBid: maxAmount,
+    tieBreakRound: auction.tieBreakRound + 1,
+    bidDeadlineAt: auctionBidDeadline(state, nowMs),
+  };
+  logs.push({
+    playerId: null,
+    actionType: "auction_tie_break",
+    payload: {
+      position: auction.tilePosition,
+      amount: maxAmount,
+      playerIds: topBidders,
+      round: newState.pendingAuction.tieBreakRound,
+    },
+  });
+  return { state: newState, logEntries: logs };
+}
+
 export function settleSealedAuction(
   state: InternalGameState,
+  nowMs: number = Date.now(),
 ): ApplyActionResult {
   const auction = state.pendingAuction;
   if (!auction || state.phase !== "waiting_for_auction_bids") {
@@ -181,38 +223,85 @@ export function settleSealedAuction(
     .map(([playerId]) => playerId);
 
   if (topBidders.length > 1) {
-    const newState = deepClone(state);
-    newState.pendingAuction = {
-      ...auction,
-      submissions: {},
-      eligiblePlayerIds: topBidders,
-      tieBreakMinBid: maxAmount,
-      tieBreakRound: auction.tieBreakRound + 1,
-    };
-    logs.push({
-      playerId: null,
-      actionType: "auction_tie_break",
-      payload: {
-        position: auction.tilePosition,
-        amount: maxAmount,
-        playerIds: topBidders,
-        round: newState.pendingAuction.tieBreakRound,
-      },
-    });
-    return { state: newState, logEntries: logs };
+    return startTieBreakRound(state, topBidders, maxAmount, nowMs, logs);
   }
 
   return awardTileToWinner(state, topBidders[0], maxAmount, logs);
+}
+
+function passForMissingBidders(
+  state: InternalGameState,
+  logs: LogEntry[],
+): InternalGameState {
+  const auction = state.pendingAuction;
+  if (!auction) return state;
+
+  const newState = deepClone(state);
+  const tile = getTileByPosition(auction.tilePosition);
+  const pendingAuction = { ...newState.pendingAuction! };
+
+  for (const playerId of getActiveEligibleBidders(newState)) {
+    if (hasAuctionSubmission(pendingAuction, playerId)) continue;
+    pendingAuction.submissions[playerId] = "pass";
+    logs.push({
+      playerId,
+      actionType: "auction_pass",
+      payload: {
+        position: auction.tilePosition,
+        name: tile?.name ?? "Unknown",
+        reason: "timeout",
+      },
+    });
+  }
+
+  newState.pendingAuction = pendingAuction;
+  return newState;
+}
+
+/**
+ * Close the sealed bid window when the deadline passes or all players submitted.
+ * Returns null when the auction should remain open.
+ */
+export function closeAuctionBidWindowIfReady(
+  state: InternalGameState,
+  nowMs: number = Date.now(),
+): ApplyActionResult | null {
+  const auction = state.pendingAuction;
+  if (!auction || state.phase !== "waiting_for_auction_bids") {
+    return null;
+  }
+
+  const allSubmitted = allEligiblePlayersSubmitted(state);
+  const windowOpen = isAuctionBidWindowOpen(auction.bidDeadlineAt, nowMs);
+  if (windowOpen && !allSubmitted) {
+    return null;
+  }
+
+  const logs: LogEntry[] = [];
+  let workingState = state;
+  if (!allSubmitted) {
+    workingState = passForMissingBidders(workingState, logs);
+  }
+
+  const settled = settleSealedAuction(workingState, nowMs);
+  return {
+    state: settled.state,
+    logEntries: [...logs, ...settled.logEntries],
+  };
 }
 
 export function recordAuctionSubmission(
   state: InternalGameState,
   playerId: string,
   submission: number | "pass",
+  nowMs: number = Date.now(),
 ): ApplyActionResult {
   const auction = state.pendingAuction;
   if (!auction || state.phase !== "waiting_for_auction_bids") {
     throw "game.auction_not_active";
+  }
+  if (!isAuctionBidWindowOpen(auction.bidDeadlineAt, nowMs)) {
+    throw "game.auction_closed";
   }
 
   if (!getActiveEligibleBidders(state).includes(playerId)) {
@@ -254,11 +343,11 @@ export function recordAuctionSubmission(
     },
   };
 
-  if (allEligiblePlayersSubmitted(newState)) {
-    const settled = settleSealedAuction(newState);
+  const closed = closeAuctionBidWindowIfReady(newState, nowMs);
+  if (closed) {
     return {
-      state: settled.state,
-      logEntries: [...logs, ...settled.logEntries],
+      state: closed.state,
+      logEntries: [...logs, ...closed.logEntries],
     };
   }
 

--- a/packages/shared/src/engine/auctionTiming.ts
+++ b/packages/shared/src/engine/auctionTiming.ts
@@ -1,0 +1,38 @@
+const SECOND_MS = 1000;
+const MINUTE_MS = 60_000;
+
+export function auctionBidWindowToMs(window: string | undefined): number {
+  switch (window) {
+    case "30s":
+      return 30 * SECOND_MS;
+    case "1min":
+      return MINUTE_MS;
+    case "5min":
+      return 5 * MINUTE_MS;
+    case "10min":
+      return 10 * MINUTE_MS;
+    case "30min":
+      return 30 * MINUTE_MS;
+    default:
+      return MINUTE_MS;
+  }
+}
+
+export function computeAuctionBidDeadline(
+  nowMs: number,
+  settings: Record<string, unknown> | undefined,
+): number {
+  const window = settings?.auctionBidWindow;
+  return (
+    nowMs +
+    auctionBidWindowToMs(typeof window === "string" ? window : undefined)
+  );
+}
+
+export function isAuctionBidWindowOpen(
+  bidDeadlineAt: number | undefined,
+  nowMs: number,
+): boolean {
+  if (bidDeadlineAt === undefined) return true;
+  return nowMs < bidDeadlineAt;
+}

--- a/packages/shared/src/engine/gameStateMachine.ts
+++ b/packages/shared/src/engine/gameStateMachine.ts
@@ -17,8 +17,8 @@ import {
   recordAuctionSubmission,
   startDeclineAuction,
 } from "./auction.js";
+import { computeAuctionBidDeadline } from "./auctionTiming.js";
 import {
-  BOARD_SIZE,
   isDiagonalChoice,
   isDoubles,
   moveOnPerimeter,
@@ -278,6 +278,14 @@ export function normalizeGameState(
   }
   if (!state.pendingAuction) {
     state.pendingAuction = undefined;
+  } else if (
+    state.phase === "waiting_for_auction_bids" &&
+    state.pendingAuction.bidDeadlineAt === undefined
+  ) {
+    state.pendingAuction.bidDeadlineAt = computeAuctionBidDeadline(
+      Date.now(),
+      state.settings,
+    );
   }
   // If phase is old-style "market_event" or "action", map to new phases
   if (state.phase === "market_event") {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -128,6 +128,7 @@ export {
 export type { PendingAuctionState } from "./engine/auction.js";
 export {
   allEligiblePlayersSubmitted,
+  closeAuctionBidWindowIfReady,
   getActiveEligibleBidders,
   hasAuctionSubmission,
   recordAuctionSubmission,
@@ -135,6 +136,11 @@ export {
   startDeclineAuction,
   suggestAiAuctionBid,
 } from "./engine/auction.js";
+export {
+  auctionBidWindowToMs,
+  computeAuctionBidDeadline,
+  isAuctionBidWindowOpen,
+} from "./engine/auctionTiming.js";
 export {
   validateContributionWeights,
   validateRevenueSplit,

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -647,6 +647,7 @@ export const PendingAuctionSchema = z.object({
   tieBreakMinBid: z.number().int().min(1).optional(),
   tieBreakRound: z.number().int().min(0).optional(),
   resumePhase: z.enum(["action", "rolling_doubles"]),
+  bidDeadlineAt: z.number().int().optional(),
   /** Present in redacted client views; omitted from persisted engine state. */
   submissionCount: z.number().int().min(0).optional(),
   /** Present in redacted player views; omitted from persisted engine state. */
@@ -827,8 +828,9 @@ export const GameRealtimeEventSchema = z.discriminatedUnion("type", [
     type: z.literal("game.timer"),
     sentAt: z.number(),
     gameId: z.string(),
-    currentPlayerId: z.string(),
+    currentPlayerId: z.string().optional(),
     deadlineAt: z.number().nullable(),
+    timerKind: z.enum(["turn", "auction_bids"]).optional(),
   }),
   z.object({
     type: z.literal("game.ai_action"),

--- a/packages/web/src/components/AuctionPanel.tsx
+++ b/packages/web/src/components/AuctionPanel.tsx
@@ -50,6 +50,9 @@ export function AuctionPanel({
       <p className="muted">
         Minimum bid: {currency}
         {minBid}. Submissions: {submissionCount}/{eligibleCount}
+        {auction.bidDeadlineAt
+          ? ` · closes ${new Date(auction.bidDeadlineAt).toLocaleTimeString()}`
+          : ""}
       </p>
 
       {!eligible && (

--- a/packages/web/src/hooks/useGameRealtime.ts
+++ b/packages/web/src/hooks/useGameRealtime.ts
@@ -22,6 +22,7 @@ export function useGameRealtime(
 ) {
   const [wsStatus, setWsStatus] = useState("disconnected");
   const [turnDeadline, setTurnDeadline] = useState<number | null>(null);
+  const [timerKind, setTimerKind] = useState<"turn" | "auction_bids">("turn");
   const onUpdateRef = useRef(options.onUpdate);
   onUpdateRef.current = options.onUpdate;
 
@@ -69,6 +70,9 @@ export function useGameRealtime(
         }
         if (message.type === "game.timer" && "deadlineAt" in message) {
           setTurnDeadline(message.deadlineAt ?? null);
+          if (message.timerKind) {
+            setTimerKind(message.timerKind);
+          }
         }
       } catch {
         // Ignore malformed websocket payloads.
@@ -78,5 +82,5 @@ export function useGameRealtime(
     return () => socket.close();
   }, [gameId]);
 
-  return { wsStatus, turnDeadline };
+  return { wsStatus, turnDeadline, timerKind };
 }

--- a/packages/web/src/hooks/useGameSession.ts
+++ b/packages/web/src/hooks/useGameSession.ts
@@ -67,7 +67,7 @@ export function useGameSession(
     setStatusLine(update.source);
   }, []);
 
-  const { wsStatus, turnDeadline } = useGameRealtime(gameId, {
+  const { wsStatus, turnDeadline, timerKind } = useGameRealtime(gameId, {
     onUpdate: applySessionUpdate,
   });
 
@@ -184,6 +184,7 @@ export function useGameSession(
     statusLine,
     wsStatus,
     turnDeadline,
+    timerKind,
     myPlayerId,
     myTurn: state ? isMyTurn(state, myPlayerId) : false,
     currentPlayerId: state ? currentActorId(state) : null,

--- a/packages/web/src/pages/GameDetailPage.tsx
+++ b/packages/web/src/pages/GameDetailPage.tsx
@@ -21,6 +21,7 @@ export function GameDetailPage() {
     statusLine,
     wsStatus,
     turnDeadline,
+    timerKind,
     myPlayerId,
     myTurn,
     runAction,
@@ -113,7 +114,9 @@ export function GameDetailPage() {
               <dd>{wsStatus}</dd>
               <dt className="muted">Your turn</dt>
               <dd>{myTurn ? "Yes" : "No"}</dd>
-              <dt className="muted">Turn deadline</dt>
+              <dt className="muted">
+                {timerKind === "auction_bids" ? "Auction closes" : "Turn deadline"}
+              </dt>
               <dd>
                 {turnDeadline
                   ? new Date(turnDeadline).toLocaleTimeString()

--- a/packages/web/src/pages/GameDetailPage.tsx
+++ b/packages/web/src/pages/GameDetailPage.tsx
@@ -115,7 +115,9 @@ export function GameDetailPage() {
               <dt className="muted">Your turn</dt>
               <dd>{myTurn ? "Yes" : "No"}</dd>
               <dt className="muted">
-                {timerKind === "auction_bids" ? "Auction closes" : "Turn deadline"}
+                {timerKind === "auction_bids"
+                  ? "Auction closes"
+                  : "Turn deadline"}
               </dt>
               <dd>
                 {turnDeadline

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -1,9 +1,14 @@
-import { isAiControlledActor, normalizeGameState } from "@oligopoly/shared";
 import {
+  findNextAiAuctionActor,
+  isAiControlledActor,
+  normalizeGameState,
+} from "@oligopoly/shared";
+import {
+  applyAuctionBidWindowExpiry,
   applyTimeoutTakeoverAndStep,
   runAiTurnLoop,
 } from "../services/gameAi.js";
-import { syncTurnTimer } from "../services/gameScheduler.js";
+import { syncGameRoomTimer } from "../services/gameScheduler.js";
 import { currentTurnActorId } from "../services/turnTimeout.js";
 
 type RoomEnv = {
@@ -161,10 +166,13 @@ export class GameRoom extends RealtimeRoom {
 
   async alarm(): Promise<void> {
     const gameId = await this.state.storage.get<string>("gameId");
-    const actorId = await this.state.storage.get<string>("turnActorId");
-    if (!gameId || !actorId || !this.env.DB) return;
+    if (!gameId || !this.env.DB) return;
 
-    const deadline = await this.state.storage.get<number>("turnDeadlineAt");
+    const timerKind =
+      (await this.state.storage.get<string>("timerKind")) ?? "turn";
+    const deadline =
+      (await this.state.storage.get<number>("timerDeadlineAt")) ??
+      (await this.state.storage.get<number>("turnDeadlineAt"));
     if (deadline && Date.now() < deadline) {
       await this.state.storage.setAlarm(deadline);
       return;
@@ -172,12 +180,22 @@ export class GameRoom extends RealtimeRoom {
 
     await this.state.storage.put("aiLoopRunning", true);
     try {
-      await applyTimeoutTakeoverAndStep(
-        this.env.DB,
-        gameId,
-        actorId,
-        this.env.GAME_ROOM,
-      );
+      if (timerKind === "auction_bids") {
+        await applyAuctionBidWindowExpiry(
+          this.env.DB,
+          gameId,
+          this.env.GAME_ROOM,
+        );
+      } else {
+        const actorId = await this.state.storage.get<string>("turnActorId");
+        if (!actorId) return;
+        await applyTimeoutTakeoverAndStep(
+          this.env.DB,
+          gameId,
+          actorId,
+          this.env.GAME_ROOM,
+        );
+      }
     } finally {
       await this.state.storage.delete("aiLoopRunning");
       await this.resyncFromDatabase(gameId);
@@ -245,6 +263,21 @@ export class GameRoom extends RealtimeRoom {
       return;
     }
 
+    if (
+      state.phase === "waiting_for_auction_bids" &&
+      this.env.DB &&
+      !(await this.state.storage.get<boolean>("aiLoopRunning"))
+    ) {
+      if (findNextAiAuctionActor(state)) {
+        await this.runAiLoop(gameId);
+        return;
+      }
+      await syncGameRoomTimer(this.state.storage, gameId, state, (message) =>
+        this.broadcast(message),
+      );
+      return;
+    }
+
     const actorId = currentTurnActorId(state);
     if (!actorId) return;
 
@@ -257,7 +290,7 @@ export class GameRoom extends RealtimeRoom {
       return;
     }
 
-    await syncTurnTimer(this.state.storage, gameId, state, (message) =>
+    await syncGameRoomTimer(this.state.storage, gameId, state, (message) =>
       this.broadcast(message),
     );
   }
@@ -277,7 +310,7 @@ export class GameRoom extends RealtimeRoom {
         const latest = normalizeGameState(
           JSON.parse(row.state_json) as Record<string, unknown>,
         );
-        await syncTurnTimer(this.state.storage, gameId, latest, (message) =>
+        await syncGameRoomTimer(this.state.storage, gameId, latest, (message) =>
           this.broadcast(message),
         );
       }

--- a/packages/worker/src/services/gameAi.ts
+++ b/packages/worker/src/services/gameAi.ts
@@ -3,6 +3,7 @@ import {
   applyAction,
   applyTimeoutTakeover,
   chooseAiAction,
+  closeAuctionBidWindowIfReady,
   type InternalGameState,
   isAiControlledActor,
   normalizeGameState,
@@ -127,6 +128,35 @@ export async function persistStateMutation(
     { state: nextState, logEntries },
     { gameRoom, actorId: "system" },
   );
+}
+
+export async function applyAuctionBidWindowExpiry(
+  db: D1Database,
+  gameId: string,
+  gameRoom?: DurableObjectNamespace,
+): Promise<boolean> {
+  const row = await loadActiveGame(db, gameId);
+  if (!row) return false;
+
+  const gameState = normalizeGameState(
+    JSON.parse(row.state_json!) as Record<string, unknown>,
+  );
+  const result = closeAuctionBidWindowIfReady(gameState, Date.now());
+  if (!result) return false;
+
+  await persistGameActionResult(db, gameId, result, {
+    gameRoom,
+    actorId: "system",
+  });
+
+  if (
+    result.state.phase === "waiting_for_auction_bids" &&
+    chooseAiAction(result.state)
+  ) {
+    await runAiTurnLoop(db, gameId, gameRoom);
+  }
+
+  return true;
 }
 
 export async function applyTimeoutTakeoverAndStep(

--- a/packages/worker/src/services/gameScheduler.ts
+++ b/packages/worker/src/services/gameScheduler.ts
@@ -1,22 +1,28 @@
 import type { InternalGameState } from "@oligopoly/shared";
 import { currentTurnActorId, turnTimeoutToMs } from "./turnTimeout.js";
 
+export type GameTimerKind = "turn" | "auction_bids";
+
 export function timerEventJson(
   gameId: string,
-  currentPlayerId: string,
-  deadlineAt: number | null,
+  options: {
+    deadlineAt: number | null;
+    timerKind?: GameTimerKind;
+    currentPlayerId?: string | null;
+  },
 ): string {
   return JSON.stringify({
     type: "game.timer",
     sentAt: Date.now(),
     gameId,
-    currentPlayerId,
-    deadlineAt,
+    timerKind: options.timerKind ?? "turn",
+    currentPlayerId: options.currentPlayerId ?? undefined,
+    deadlineAt: options.deadlineAt,
   });
 }
 
-/** Sync turn-timeout alarm + broadcast `game.timer` from canonical game state. */
-export async function syncTurnTimer(
+/** Sync GameRoom alarm + broadcast `game.timer` from canonical game state. */
+export async function syncGameRoomTimer(
   storage: DurableObjectStorage,
   gameId: string,
   state: InternalGameState,
@@ -24,25 +30,68 @@ export async function syncTurnTimer(
 ): Promise<void> {
   if (state.phase === "game_over") {
     await storage.deleteAlarm();
+    await storage.delete("timerKind");
+    return;
+  }
+
+  if (
+    state.phase === "waiting_for_auction_bids" &&
+    state.pendingAuction?.bidDeadlineAt
+  ) {
+    const deadlineAt = state.pendingAuction.bidDeadlineAt;
+    await storage.put("timerKind", "auction_bids");
+    await storage.put("timerDeadlineAt", deadlineAt);
+    await storage.delete("turnActorId");
+    await storage.delete("turnDeadlineAt");
+    await storage.setAlarm(deadlineAt);
+    broadcast(
+      timerEventJson(gameId, {
+        deadlineAt,
+        timerKind: "auction_bids",
+      }),
+    );
     return;
   }
 
   const actorId = currentTurnActorId(state);
-  if (!actorId) return;
+  if (!actorId) {
+    await storage.deleteAlarm();
+    return;
+  }
 
   const timeoutMs = turnTimeoutToMs(
     (state.settings?.turnTimeout as string | undefined) ?? "5min",
   );
 
+  await storage.put("timerKind", "turn");
+
   if (timeoutMs === null) {
     await storage.deleteAlarm();
-    broadcast(timerEventJson(gameId, actorId, null));
+    await storage.delete("turnActorId");
+    await storage.delete("turnDeadlineAt");
+    broadcast(
+      timerEventJson(gameId, {
+        deadlineAt: null,
+        timerKind: "turn",
+        currentPlayerId: actorId,
+      }),
+    );
     return;
   }
 
   const deadlineAt = Date.now() + timeoutMs;
   await storage.put("turnActorId", actorId);
   await storage.put("turnDeadlineAt", deadlineAt);
+  await storage.put("timerDeadlineAt", deadlineAt);
   await storage.setAlarm(deadlineAt);
-  broadcast(timerEventJson(gameId, actorId, deadlineAt));
+  broadcast(
+    timerEventJson(gameId, {
+      deadlineAt,
+      timerKind: "turn",
+      currentPlayerId: actorId,
+    }),
+  );
 }
+
+/** @deprecated Use syncGameRoomTimer */
+export const syncTurnTimer = syncGameRoomTimer;

--- a/tests/unit/auctionTiming.test.ts
+++ b/tests/unit/auctionTiming.test.ts
@@ -1,0 +1,25 @@
+import {
+  auctionBidWindowToMs,
+  computeAuctionBidDeadline,
+  isAuctionBidWindowOpen,
+} from "@oligopoly/shared";
+import { describe, expect, it } from "vitest";
+
+describe("auctionTiming", () => {
+  it("maps lobby bid windows to milliseconds", () => {
+    expect(auctionBidWindowToMs("30s")).toBe(30_000);
+    expect(auctionBidWindowToMs("1min")).toBe(60_000);
+    expect(auctionBidWindowToMs("5min")).toBe(300_000);
+  });
+
+  it("computes bid deadlines from game settings", () => {
+    const now = 1_700_000_000_000;
+    expect(computeAuctionBidDeadline(now, { auctionBidWindow: "30s" })).toBe(
+      now + 30_000,
+    );
+  });
+
+  it("treats missing deadlines as open windows", () => {
+    expect(isAuctionBidWindowOpen(undefined, Date.now())).toBe(true);
+  });
+});

--- a/tests/unit/shared.test.ts
+++ b/tests/unit/shared.test.ts
@@ -25,6 +25,7 @@ import {
   checkSyndicateWin,
   chooseAiAction,
   clampTrustworthiness,
+  closeAuctionBidWindowIfReady,
   DEFAULT_CONTRIBUTION_WEIGHTS,
   DEFAULT_PROFILE_VISIBILITY,
   FLASH_CRASH_LOSS_PCT,
@@ -1646,6 +1647,9 @@ describe("applyAction — buy_tile / decline_tile", () => {
     expect(result.state.pendingBuyTilePosition).toBeNull();
     expect(result.state.pendingAuction?.tilePosition).toBe(3);
     expect(result.state.pendingAuction?.auctionType).toBe("sealed_bids");
+    expect(result.state.pendingAuction?.bidDeadlineAt).toBeGreaterThan(
+      Date.now(),
+    );
     expect(result.state.pendingAuction?.eligiblePlayerIds).toEqual([
       "player-1",
       "player-2",
@@ -1654,6 +1658,8 @@ describe("applyAction — buy_tile / decline_tile", () => {
 });
 
 describe("applyAction — auction_bid / auction_pass", () => {
+  const openAuctionDeadline = Date.now() + 60 * 60 * 1000;
+
   function makeAuctionState(
     overrides?: Partial<InternalGameState>,
   ): InternalGameState {
@@ -1668,6 +1674,7 @@ describe("applyAction — auction_bid / auction_pass", () => {
         eligiblePlayerIds: ["player-1", "player-2"],
         tieBreakRound: 0,
         resumePhase: "action",
+        bidDeadlineAt: openAuctionDeadline,
       },
       ...overrides,
     });
@@ -1746,6 +1753,7 @@ describe("applyAction — auction_bid / auction_pass", () => {
         tieBreakMinBid: 75,
         tieBreakRound: 1,
         resumePhase: "action",
+        bidDeadlineAt: openAuctionDeadline,
       },
     });
     expect(() =>
@@ -1783,6 +1791,7 @@ describe("applyAction — auction_bid / auction_pass", () => {
         eligiblePlayerIds: ["player-1", "player-2"],
         tieBreakRound: 0,
         resumePhase: "action",
+        bidDeadlineAt: openAuctionDeadline,
       },
     });
     const settled = applyAction(state, "player-2", {
@@ -1798,6 +1807,49 @@ describe("applyAction — auction_bid / auction_pass", () => {
         (entry) => entry.actionType === "auction_settled",
       ),
     ).toBe(true);
+  });
+
+  it("auto-passes missing bidders when the bid window expires", () => {
+    const state = makeAuctionState({
+      pendingAuction: {
+        tilePosition: 3,
+        trigger: "decline",
+        auctionType: "sealed_bids",
+        submissions: { "player-1": 80 },
+        eligiblePlayerIds: ["player-1", "player-2"],
+        tieBreakRound: 0,
+        resumePhase: "action",
+        bidDeadlineAt: Date.now() - 1,
+      },
+    });
+    const closed = closeAuctionBidWindowIfReady(state, Date.now());
+    expect(closed?.state.phase).toBe("action");
+    const winner = closed?.state.players.find(
+      (player) => player.playerId === "player-1",
+    );
+    expect(winner?.ownedTilePositions).toContain(3);
+  });
+
+  it("rejects bids after the bid window closes", () => {
+    const state = makeAuctionState({
+      pendingAuction: {
+        tilePosition: 3,
+        trigger: "decline",
+        auctionType: "sealed_bids",
+        submissions: {},
+        eligiblePlayerIds: ["player-1", "player-2"],
+        tieBreakRound: 0,
+        resumePhase: "action",
+        bidDeadlineAt: Date.now() - 1,
+      },
+    });
+    expect(() =>
+      applyAction(state, "player-1", {
+        type: "auction_bid",
+        tilePosition: 3,
+        amount: 50,
+      }),
+    ).toThrow("game.auction_closed");
   });
 });
 

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1023,6 +1023,7 @@ describe("GameStateSchema (enhanced)", () => {
         resumePhase: "action",
         submissionCount: 1,
         mySubmission: 90,
+        bidDeadlineAt: Date.now() + 60_000,
       },
     });
     expect(result.success).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **sealed auction bid-window timers** from lobby settings (`auctionBidWindow`), continuing end-to-end gameplay from main (#52).

### Engine
- `auctionTiming.ts` — maps lobby bid windows to ms; sets `pendingAuction.bidDeadlineAt` on decline/tie-break
- `closeAuctionBidWindowIfReady` — auto-passes missing bidders on expiry, then settles (still settles early when all submit)
- Rejects bids after deadline (`game.auction_closed`)
- `normalizeGameState` backfills missing `bidDeadlineAt` for in-flight auctions on deploy

### Worker / GameRoom
- `syncGameRoomTimer` arms auction alarms; emits `game.timer` with `timerKind: "auction_bids"`
- Alarm closes bid window via `applyAuctionBidWindowExpiry`
- AI loop runs during auction for any AI seat without a submission
- Legacy DO alarm guard: `timerDeadlineAt ?? turnDeadlineAt`

### Client
- Auction panel shows close time; play panel labels “Auction closes” vs “Turn deadline”

### Deferred
- `auctionSettleDelay` reveal phase
- Open/live auction modes

## Review responses (thermo-nuclear self-review)

| Finding | Fix |
|---|---|
| Missing committed `auctionTiming.ts` | Committed in feature commit |
| DO alarm early-fire without legacy key | `timerDeadlineAt ?? turnDeadlineAt` fallback |
| In-flight auctions missing deadline | Backfill in `normalizeGameState` |
| AI only stepped on current turn during auction | `syncAfterStateChange` runs AI when `findNextAiAuctionActor` |

## Verification

- CI green
- `pnpm run test:unit` — 306 passed
- `pnpm run test:integration` — 140 passed
- `pnpm run test:e2e` — 2 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b220472-5252-4354-a7c0-315bebd6b719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b220472-5252-4354-a7c0-315bebd6b719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

