### PR TITLE
Auction settle delay phase before bid reveal

### DIFF
--- a/oligopoly_technical_plan.md
+++ b/oligopoly_technical_plan.md
@@ -602,7 +602,7 @@ No deployment-specific delivery or session keys are defined in this plan.
 - Sealed bid amounts are redacted in HTTP/WS player views (`toClientGameState`) and stripped from broadcast snapshots (`publicStateForBroadcast`); only the viewer's own **`mySubmission`** is returned until settlement reveals all bids in the action log.
 - Per-player **`auction_bid`** log entries omit bid amounts until **`auction_settled`** reveals all submissions simultaneously.
 - **`GameRoom`** AI loop uses **`findNextAiAuctionActor`** / **`chooseAiActionForPlayer`** to submit bids for AI seats without a submission. **`GameRoom.syncAfterStateChange`** runs the AI loop during **`waiting_for_auction_bids`** whenever an AI seat still owes a submission, not only on the current turn actor.
-- Sealed auctions honor **`settings.auctionBidWindow`**: **`pendingAuction.bidDeadlineAt`** is set at decline/tie-break start; **`closeAuctionBidWindowIfReady`** auto-passes missing bidders and settles when the deadline passes (or immediately when all eligible players submit). **`GameRoom`** alarms on the bid deadline via **`syncGameRoomTimer`**. Auction settle delay remains deferred.
+- Sealed auctions honor **`settings.auctionBidWindow`**: **`pendingAuction.bidDeadlineAt`** is set at decline/tie-break start; **`closeAuctionBidWindowIfReady`** auto-passes missing bidders and enters **`waiting_for_auction_settle`** when the bid window closes (or when all eligible players submit). **`settings.auctionSettleDelay`** sets **`pendingAuction.settleDeadlineAt`**; **`finalizeAuctionSettleIfReady`** reveals bids and settles after the delay. **`GameRoom`** alarms on bid/settle deadlines via **`syncGameRoomTimer`** (`timerKind`: `auction_bids` | `auction_settle`).
 
 ---
 

--- a/packages/shared/src/engine/auction.ts
+++ b/packages/shared/src/engine/auction.ts
@@ -1,7 +1,9 @@
 import { getTileByPosition } from "../config/board.js";
 import {
   computeAuctionBidDeadline,
+  computeAuctionSettleDeadline,
   isAuctionBidWindowOpen,
+  isAuctionSettleDelayActive,
 } from "./auctionTiming.js";
 import { rollFairD6 } from "./dice.js";
 import type {
@@ -21,6 +23,7 @@ export type PendingAuctionState = {
   tieBreakRound: number;
   resumePhase: "action" | "rolling_doubles";
   bidDeadlineAt: number;
+  settleDeadlineAt?: number;
 };
 
 function deepClone<T>(obj: T): T {
@@ -169,6 +172,7 @@ function startTieBreakRound(
 ): ApplyActionResult {
   const auction = state.pendingAuction!;
   const newState = deepClone(state);
+  newState.phase = "waiting_for_auction_bids";
   newState.pendingAuction = {
     ...auction,
     submissions: {},
@@ -176,6 +180,7 @@ function startTieBreakRound(
     tieBreakMinBid: maxAmount,
     tieBreakRound: auction.tieBreakRound + 1,
     bidDeadlineAt: auctionBidDeadline(state, nowMs),
+    settleDeadlineAt: undefined,
   };
   logs.push({
     playerId: null,
@@ -195,7 +200,11 @@ export function settleSealedAuction(
   nowMs: number = Date.now(),
 ): ApplyActionResult {
   const auction = state.pendingAuction;
-  if (!auction || state.phase !== "waiting_for_auction_bids") {
+  if (
+    !auction ||
+    (state.phase !== "waiting_for_auction_settle" &&
+      state.phase !== "waiting_for_auction_bids")
+  ) {
     throw "game.auction_not_active";
   }
 
@@ -258,9 +267,39 @@ function passForMissingBidders(
   return newState;
 }
 
+function beginAuctionSettlePhase(
+  state: InternalGameState,
+  nowMs: number,
+  logs: LogEntry[],
+): ApplyActionResult {
+  const auction = state.pendingAuction;
+  if (!auction) {
+    throw "game.auction_not_active";
+  }
+
+  const tile = getTileByPosition(auction.tilePosition);
+  const newState = deepClone(state);
+  newState.phase = "waiting_for_auction_settle";
+  newState.pendingAuction = {
+    ...auction,
+    settleDeadlineAt: computeAuctionSettleDeadline(nowMs, state.settings),
+  };
+
+  logs.push({
+    playerId: null,
+    actionType: "auction_bids_closed",
+    payload: {
+      position: auction.tilePosition,
+      name: tile?.name ?? "Unknown",
+    },
+  });
+
+  return { state: newState, logEntries: logs };
+}
+
 /**
  * Close the sealed bid window when the deadline passes or all players submitted.
- * Returns null when the auction should remain open.
+ * Returns null when the auction should remain open for bids.
  */
 export function closeAuctionBidWindowIfReady(
   state: InternalGameState,
@@ -283,11 +322,26 @@ export function closeAuctionBidWindowIfReady(
     workingState = passForMissingBidders(workingState, logs);
   }
 
-  const settled = settleSealedAuction(workingState, nowMs);
-  return {
-    state: settled.state,
-    logEntries: [...logs, ...settled.logEntries],
-  };
+  return beginAuctionSettlePhase(workingState, nowMs, logs);
+}
+
+/**
+ * Reveal bids and settle after the configured settle delay.
+ * Returns null while the settle countdown is still active.
+ */
+export function finalizeAuctionSettleIfReady(
+  state: InternalGameState,
+  nowMs: number = Date.now(),
+): ApplyActionResult | null {
+  const auction = state.pendingAuction;
+  if (!auction || state.phase !== "waiting_for_auction_settle") {
+    return null;
+  }
+  if (isAuctionSettleDelayActive(auction.settleDeadlineAt, nowMs)) {
+    return null;
+  }
+
+  return settleSealedAuction(state, nowMs);
 }
 
 export function recordAuctionSubmission(

--- a/packages/shared/src/engine/auctionTiming.ts
+++ b/packages/shared/src/engine/auctionTiming.ts
@@ -18,6 +18,21 @@ export function auctionBidWindowToMs(window: string | undefined): number {
   }
 }
 
+export function auctionSettleDelayToMs(delay: string | undefined): number {
+  switch (delay) {
+    case "10s":
+      return 10 * SECOND_MS;
+    case "30s":
+      return 30 * SECOND_MS;
+    case "1min":
+      return MINUTE_MS;
+    case "5min":
+      return 5 * MINUTE_MS;
+    default:
+      return 30 * SECOND_MS;
+  }
+}
+
 export function computeAuctionBidDeadline(
   nowMs: number,
   settings: Record<string, unknown> | undefined,
@@ -29,10 +44,29 @@ export function computeAuctionBidDeadline(
   );
 }
 
+export function computeAuctionSettleDeadline(
+  nowMs: number,
+  settings: Record<string, unknown> | undefined,
+): number {
+  const delay = settings?.auctionSettleDelay;
+  return (
+    nowMs +
+    auctionSettleDelayToMs(typeof delay === "string" ? delay : undefined)
+  );
+}
+
 export function isAuctionBidWindowOpen(
   bidDeadlineAt: number | undefined,
   nowMs: number,
 ): boolean {
   if (bidDeadlineAt === undefined) return true;
   return nowMs < bidDeadlineAt;
+}
+
+export function isAuctionSettleDelayActive(
+  settleDeadlineAt: number | undefined,
+  nowMs: number,
+): boolean {
+  if (settleDeadlineAt === undefined) return false;
+  return nowMs < settleDeadlineAt;
 }

--- a/packages/shared/src/engine/gameStateMachine.ts
+++ b/packages/shared/src/engine/gameStateMachine.ts
@@ -17,7 +17,10 @@ import {
   recordAuctionSubmission,
   startDeclineAuction,
 } from "./auction.js";
-import { computeAuctionBidDeadline } from "./auctionTiming.js";
+import {
+  computeAuctionBidDeadline,
+  computeAuctionSettleDeadline,
+} from "./auctionTiming.js";
 import {
   isDiagonalChoice,
   isDoubles,
@@ -283,6 +286,14 @@ export function normalizeGameState(
     state.pendingAuction.bidDeadlineAt === undefined
   ) {
     state.pendingAuction.bidDeadlineAt = computeAuctionBidDeadline(
+      Date.now(),
+      state.settings,
+    );
+  } else if (
+    state.phase === "waiting_for_auction_settle" &&
+    state.pendingAuction.settleDeadlineAt === undefined
+  ) {
+    state.pendingAuction.settleDeadlineAt = computeAuctionSettleDeadline(
       Date.now(),
       state.settings,
     );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -129,6 +129,7 @@ export type { PendingAuctionState } from "./engine/auction.js";
 export {
   allEligiblePlayersSubmitted,
   closeAuctionBidWindowIfReady,
+  finalizeAuctionSettleIfReady,
   getActiveEligibleBidders,
   hasAuctionSubmission,
   recordAuctionSubmission,
@@ -138,8 +139,11 @@ export {
 } from "./engine/auction.js";
 export {
   auctionBidWindowToMs,
+  auctionSettleDelayToMs,
   computeAuctionBidDeadline,
+  computeAuctionSettleDeadline,
   isAuctionBidWindowOpen,
+  isAuctionSettleDelayActive,
 } from "./engine/auctionTiming.js";
 export {
   validateContributionWeights,

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -595,6 +595,7 @@ export const GamePhaseSchema = z.enum([
   "waiting_for_roll",
   "waiting_for_buy",
   "waiting_for_auction_bids",
+  "waiting_for_auction_settle",
   "waiting_for_path_choice",
   "rolling_doubles",
   "game_over",
@@ -648,6 +649,7 @@ export const PendingAuctionSchema = z.object({
   tieBreakRound: z.number().int().min(0).optional(),
   resumePhase: z.enum(["action", "rolling_doubles"]),
   bidDeadlineAt: z.number().int().optional(),
+  settleDeadlineAt: z.number().int().optional(),
   /** Present in redacted client views; omitted from persisted engine state. */
   submissionCount: z.number().int().min(0).optional(),
   /** Present in redacted player views; omitted from persisted engine state. */
@@ -830,7 +832,7 @@ export const GameRealtimeEventSchema = z.discriminatedUnion("type", [
     gameId: z.string(),
     currentPlayerId: z.string().optional(),
     deadlineAt: z.number().nullable(),
-    timerKind: z.enum(["turn", "auction_bids"]).optional(),
+    timerKind: z.enum(["turn", "auction_bids", "auction_settle"]).optional(),
   }),
   z.object({
     type: z.literal("game.ai_action"),

--- a/packages/web/src/components/AuctionPanel.tsx
+++ b/packages/web/src/components/AuctionPanel.tsx
@@ -5,6 +5,7 @@ import {
   activeEligibleAuctionPlayers,
   canParticipateInAuction,
   hasSubmittedAuction,
+  isAuctionBiddingPhase,
   isAuctionPhase,
 } from "../lib/gameUi";
 
@@ -30,6 +31,8 @@ export function AuctionPanel({
     return null;
   }
 
+  const bidding = isAuctionBiddingPhase(state);
+
   const currency = state.settings?.currencySymbol ?? "¤";
   const tileName = tileLabel(auction.tilePosition, tileNames);
   const minBid = auction.tieBreakMinBid ?? 1;
@@ -40,7 +43,7 @@ export function AuctionPanel({
 
   return (
     <div className="auctionPanel">
-      <h3>Sealed auction</h3>
+      <h3>{bidding ? "Sealed auction" : "Auction settling"}</h3>
       <p>
         Bidding on <strong>{tileName}</strong>
         {auction.tieBreakRound
@@ -48,22 +51,36 @@ export function AuctionPanel({
           : ""}
       </p>
       <p className="muted">
-        Minimum bid: {currency}
-        {minBid}. Submissions: {submissionCount}/{eligibleCount}
-        {auction.bidDeadlineAt
-          ? ` · closes ${new Date(auction.bidDeadlineAt).toLocaleTimeString()}`
-          : ""}
+        {bidding ? (
+          <>
+            Minimum bid: {currency}
+            {minBid}. Submissions: {submissionCount}/{eligibleCount}
+            {auction.bidDeadlineAt
+              ? ` · closes ${new Date(auction.bidDeadlineAt).toLocaleTimeString()}`
+              : ""}
+          </>
+        ) : (
+          <>
+            Bids are sealed. Revealing results
+            {auction.settleDeadlineAt
+              ? ` at ${new Date(auction.settleDeadlineAt).toLocaleTimeString()}`
+              : " soon"}
+            .
+          </>
+        )}
       </p>
 
-      {!eligible && (
+      {!bidding && <p className="muted">No further bids can be submitted.</p>}
+
+      {bidding && !eligible && (
         <p className="muted">You are not eligible to bid in this auction.</p>
       )}
 
-      {eligible && submitted && (
+      {bidding && eligible && submitted && (
         <p className="ok">Your sealed bid has been submitted.</p>
       )}
 
-      {eligible && !submitted && (
+      {bidding && eligible && !submitted && (
         <>
           <label className="muted" htmlFor="auction-bid-amount">
             Bid amount

--- a/packages/web/src/hooks/useGameRealtime.ts
+++ b/packages/web/src/hooks/useGameRealtime.ts
@@ -22,7 +22,9 @@ export function useGameRealtime(
 ) {
   const [wsStatus, setWsStatus] = useState("disconnected");
   const [turnDeadline, setTurnDeadline] = useState<number | null>(null);
-  const [timerKind, setTimerKind] = useState<"turn" | "auction_bids">("turn");
+  const [timerKind, setTimerKind] = useState<
+    "turn" | "auction_bids" | "auction_settle"
+  >("turn");
   const onUpdateRef = useRef(options.onUpdate);
   onUpdateRef.current = options.onUpdate;
 

--- a/packages/web/src/lib/gameLogDisplay.ts
+++ b/packages/web/src/lib/gameLogDisplay.ts
@@ -14,7 +14,7 @@ const ACTION_LABELS: Record<string, string> = {
   pay_rent: "Paid rent",
   pass_start: "Passed start",
   timeout_takeover: "Timeout takeover",
-  auction_started: "Auction started",
+  auction_bids_closed: "Auction bids closed",
   auction_bid: "Auction bid",
   auction_pass: "Passed auction",
   auction_settled: "Auction settled",

--- a/packages/web/src/lib/gameUi.ts
+++ b/packages/web/src/lib/gameUi.ts
@@ -28,6 +28,14 @@ export function isMyTurn(state: GameState, myPlayerId: string | null): boolean {
 
 export function isAuctionPhase(state: GameState): boolean {
   return (
+    (state.phase === "waiting_for_auction_bids" ||
+      state.phase === "waiting_for_auction_settle") &&
+    Boolean(state.pendingAuction)
+  );
+}
+
+export function isAuctionBiddingPhase(state: GameState): boolean {
+  return (
     state.phase === "waiting_for_auction_bids" && Boolean(state.pendingAuction)
   );
 }

--- a/packages/web/src/pages/GameDetailPage.tsx
+++ b/packages/web/src/pages/GameDetailPage.tsx
@@ -117,7 +117,9 @@ export function GameDetailPage() {
               <dt className="muted">
                 {timerKind === "auction_bids"
                   ? "Auction closes"
-                  : "Turn deadline"}
+                  : timerKind === "auction_settle"
+                    ? "Auction reveals"
+                    : "Turn deadline"}
               </dt>
               <dd>
                 {turnDeadline

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -5,6 +5,7 @@ import {
 } from "@oligopoly/shared";
 import {
   applyAuctionBidWindowExpiry,
+  applyAuctionSettleExpiry,
   applyTimeoutTakeoverAndStep,
   runAiTurnLoop,
 } from "../services/gameAi.js";
@@ -186,6 +187,8 @@ export class GameRoom extends RealtimeRoom {
           gameId,
           this.env.GAME_ROOM,
         );
+      } else if (timerKind === "auction_settle") {
+        await applyAuctionSettleExpiry(this.env.DB, gameId, this.env.GAME_ROOM);
       } else {
         const actorId = await this.state.storage.get<string>("turnActorId");
         if (!actorId) return;
@@ -272,6 +275,12 @@ export class GameRoom extends RealtimeRoom {
         await this.runAiLoop(gameId);
         return;
       }
+    }
+
+    if (
+      state.phase === "waiting_for_auction_bids" ||
+      state.phase === "waiting_for_auction_settle"
+    ) {
       await syncGameRoomTimer(this.state.storage, gameId, state, (message) =>
         this.broadcast(message),
       );

--- a/packages/worker/src/services/gameAi.ts
+++ b/packages/worker/src/services/gameAi.ts
@@ -4,6 +4,7 @@ import {
   applyTimeoutTakeover,
   chooseAiAction,
   closeAuctionBidWindowIfReady,
+  finalizeAuctionSettleIfReady,
   type InternalGameState,
   isAiControlledActor,
   normalizeGameState,
@@ -130,10 +131,11 @@ export async function persistStateMutation(
   );
 }
 
-export async function applyAuctionBidWindowExpiry(
+async function applyAuctionPhaseTransition(
   db: D1Database,
   gameId: string,
-  gameRoom?: DurableObjectNamespace,
+  gameRoom: DurableObjectNamespace | undefined,
+  transition: (state: InternalGameState) => ApplyActionResult | null,
 ): Promise<boolean> {
   const row = await loadActiveGame(db, gameId);
   if (!row) return false;
@@ -141,7 +143,7 @@ export async function applyAuctionBidWindowExpiry(
   const gameState = normalizeGameState(
     JSON.parse(row.state_json!) as Record<string, unknown>,
   );
-  const result = closeAuctionBidWindowIfReady(gameState, Date.now());
+  const result = transition(gameState);
   if (!result) return false;
 
   await persistGameActionResult(db, gameId, result, {
@@ -157,6 +159,26 @@ export async function applyAuctionBidWindowExpiry(
   }
 
   return true;
+}
+
+export async function applyAuctionBidWindowExpiry(
+  db: D1Database,
+  gameId: string,
+  gameRoom?: DurableObjectNamespace,
+): Promise<boolean> {
+  return applyAuctionPhaseTransition(db, gameId, gameRoom, (state) =>
+    closeAuctionBidWindowIfReady(state, Date.now()),
+  );
+}
+
+export async function applyAuctionSettleExpiry(
+  db: D1Database,
+  gameId: string,
+  gameRoom?: DurableObjectNamespace,
+): Promise<boolean> {
+  return applyAuctionPhaseTransition(db, gameId, gameRoom, (state) =>
+    finalizeAuctionSettleIfReady(state, Date.now()),
+  );
 }
 
 export async function applyTimeoutTakeoverAndStep(

--- a/packages/worker/src/services/gameScheduler.ts
+++ b/packages/worker/src/services/gameScheduler.ts
@@ -1,7 +1,7 @@
 import type { InternalGameState } from "@oligopoly/shared";
 import { currentTurnActorId, turnTimeoutToMs } from "./turnTimeout.js";
 
-export type GameTimerKind = "turn" | "auction_bids";
+export type GameTimerKind = "turn" | "auction_bids" | "auction_settle";
 
 export function timerEventJson(
   gameId: string,
@@ -31,6 +31,25 @@ export async function syncGameRoomTimer(
   if (state.phase === "game_over") {
     await storage.deleteAlarm();
     await storage.delete("timerKind");
+    return;
+  }
+
+  if (
+    state.phase === "waiting_for_auction_settle" &&
+    state.pendingAuction?.settleDeadlineAt
+  ) {
+    const deadlineAt = state.pendingAuction.settleDeadlineAt;
+    await storage.put("timerKind", "auction_settle");
+    await storage.put("timerDeadlineAt", deadlineAt);
+    await storage.delete("turnActorId");
+    await storage.delete("turnDeadlineAt");
+    await storage.setAlarm(deadlineAt);
+    broadcast(
+      timerEventJson(gameId, {
+        deadlineAt,
+        timerKind: "auction_settle",
+      }),
+    );
     return;
   }
 

--- a/tests/helpers/workerGameplayHarness.ts
+++ b/tests/helpers/workerGameplayHarness.ts
@@ -1,3 +1,7 @@
+import {
+  finalizeAuctionSettleIfReady,
+  normalizeGameState,
+} from "@oligopoly/shared";
 import app from "@oligopoly/worker";
 import { createWorkerD1Stub } from "./workerD1Stub.js";
 
@@ -209,6 +213,27 @@ export async function ensureActorTurn(
     );
   }
   return finalState;
+}
+
+export function advanceAuctionSettle(db: D1Database, gameId: string) {
+  const tables = (db as D1Database & { _tables: Record<string, Row[]> })
+    ._tables;
+  const gameRow = tables.games.find((row) => row.id === gameId);
+  if (!gameRow?.state_json) {
+    throw new Error(`Game ${gameId} not found`);
+  }
+
+  const state = normalizeGameState(
+    JSON.parse(gameRow.state_json as string) as Record<string, unknown>,
+  );
+  const deadline = state.pendingAuction?.settleDeadlineAt ?? Date.now();
+  const result = finalizeAuctionSettleIfReady(state, deadline + 1);
+  if (!result) {
+    throw new Error("Auction settle phase is not ready to finalize");
+  }
+
+  gameRow.state_json = JSON.stringify(result.state);
+  return result;
 }
 
 export function isActorTurn(

--- a/tests/integration/game-actions.test.ts
+++ b/tests/integration/game-actions.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  advanceAuctionSettle,
   createAndStartGame,
   createD1Stub,
   requestWithEnv,
@@ -243,14 +244,15 @@ describe("POST /api/games/:id/action — buy_tile / decline_tile", () => {
     });
     expect(settleRes.status).toBe(200);
     const settleBody = (await settleRes.json()) as Record<string, unknown>;
-    expect(settleBody.phase).toBe("action");
-    expect(settleBody.pendingAuction).toBeUndefined();
+    expect(settleBody.phase).toBe("waiting_for_auction_settle");
 
-    const players = settleBody.players as Array<{
-      playerId: string;
-      ownedTilePositions: number[];
-    }>;
-    const winner = players.find((player) => player.playerId === currentPlayer)!;
+    const finalized = advanceAuctionSettle(db, gameId);
+    expect(finalized.state.phase).toBe("action");
+    expect(finalized.state.pendingAuction).toBeUndefined();
+
+    const winner = finalized.state.players.find(
+      (player) => player.playerId === currentPlayer,
+    )!;
     expect(winner.ownedTilePositions).toContain(3);
   });
 });
@@ -417,6 +419,8 @@ describe("POST /api/games/:id/action — doubles", () => {
         },
         db,
       });
+
+      advanceAuctionSettle(db, gameId);
     }
 
     // Should be in rolling_doubles phase -> can roll again

--- a/tests/unit/auctionTiming.test.ts
+++ b/tests/unit/auctionTiming.test.ts
@@ -1,7 +1,10 @@
 import {
   auctionBidWindowToMs,
+  auctionSettleDelayToMs,
   computeAuctionBidDeadline,
+  computeAuctionSettleDeadline,
   isAuctionBidWindowOpen,
+  isAuctionSettleDelayActive,
 } from "@oligopoly/shared";
 import { describe, expect, it } from "vitest";
 
@@ -12,14 +15,24 @@ describe("auctionTiming", () => {
     expect(auctionBidWindowToMs("5min")).toBe(300_000);
   });
 
-  it("computes bid deadlines from game settings", () => {
+  it("maps lobby settle delays to milliseconds", () => {
+    expect(auctionSettleDelayToMs("10s")).toBe(10_000);
+    expect(auctionSettleDelayToMs("30s")).toBe(30_000);
+    expect(auctionSettleDelayToMs("1min")).toBe(60_000);
+  });
+
+  it("computes bid and settle deadlines from game settings", () => {
     const now = 1_700_000_000_000;
     expect(computeAuctionBidDeadline(now, { auctionBidWindow: "30s" })).toBe(
       now + 30_000,
     );
+    expect(
+      computeAuctionSettleDeadline(now, { auctionSettleDelay: "10s" }),
+    ).toBe(now + 10_000);
   });
 
   it("treats missing deadlines as open windows", () => {
     expect(isAuctionBidWindowOpen(undefined, Date.now())).toBe(true);
+    expect(isAuctionSettleDelayActive(undefined, Date.now())).toBe(false);
   });
 });

--- a/tests/unit/shared.test.ts
+++ b/tests/unit/shared.test.ts
@@ -31,6 +31,7 @@ import {
   FLASH_CRASH_LOSS_PCT,
   FLASH_CRASH_WINDFALL_PCT,
   type FullUserProfile,
+  finalizeAuctionSettleIfReady,
   getRankForPoints,
   getStartingCapital,
   getTileByPosition,
@@ -1694,10 +1695,16 @@ describe("applyAction — auction_bid / auction_pass", () => {
       tilePosition: 3,
       amount: 50,
     });
-    expect(settled.state.phase).toBe("action");
-    expect(settled.state.pendingAuction).toBeUndefined();
+    expect(settled.state.phase).toBe("waiting_for_auction_settle");
 
-    const winner = settled.state.players.find(
+    const finalized = finalizeAuctionSettleIfReady(
+      settled.state,
+      settled.state.pendingAuction!.settleDeadlineAt! + 1,
+    );
+    expect(finalized?.state.phase).toBe("action");
+    expect(finalized?.state.pendingAuction).toBeUndefined();
+
+    const winner = finalized!.state.players.find(
       (p) => p.playerId === "player-1",
     )!;
     expect(winner.capital).toBe(1500 - 90);
@@ -1714,9 +1721,14 @@ describe("applyAction — auction_bid / auction_pass", () => {
       type: "auction_pass",
       tilePosition: 3,
     });
-    expect(settled.state.phase).toBe("action");
-    expect(settled.state.pendingAuction).toBeUndefined();
-    const tile = settled.state.tiles.find((entry) => entry.position === 3);
+    expect(settled.state.phase).toBe("waiting_for_auction_settle");
+    const finalized = finalizeAuctionSettleIfReady(
+      settled.state,
+      settled.state.pendingAuction!.settleDeadlineAt! + 1,
+    );
+    expect(finalized?.state.phase).toBe("action");
+    expect(finalized?.state.pendingAuction).toBeUndefined();
+    const tile = finalized!.state.tiles.find((entry) => entry.position === 3);
     expect(tile?.ownerId).toBeNull();
   });
 
@@ -1727,19 +1739,24 @@ describe("applyAction — auction_bid / auction_pass", () => {
       tilePosition: 3,
       amount: 75,
     });
-    const tieBreak = applyAction(afterFirst.state, "player-2", {
+    const settling = applyAction(afterFirst.state, "player-2", {
       type: "auction_bid",
       tilePosition: 3,
       amount: 75,
     });
-    expect(tieBreak.state.phase).toBe("waiting_for_auction_bids");
-    expect(tieBreak.state.pendingAuction?.tieBreakRound).toBe(1);
-    expect(tieBreak.state.pendingAuction?.tieBreakMinBid).toBe(75);
-    expect(tieBreak.state.pendingAuction?.eligiblePlayerIds).toEqual([
+    expect(settling.state.phase).toBe("waiting_for_auction_settle");
+    const tieBreak = finalizeAuctionSettleIfReady(
+      settling.state,
+      settling.state.pendingAuction!.settleDeadlineAt! + 1,
+    );
+    expect(tieBreak?.state.phase).toBe("waiting_for_auction_bids");
+    expect(tieBreak?.state.pendingAuction?.tieBreakRound).toBe(1);
+    expect(tieBreak?.state.pendingAuction?.tieBreakMinBid).toBe(75);
+    expect(tieBreak?.state.pendingAuction?.eligiblePlayerIds).toEqual([
       "player-1",
       "player-2",
     ]);
-    expect(tieBreak.state.pendingAuction?.submissions).toEqual({});
+    expect(tieBreak?.state.pendingAuction?.submissions).toEqual({});
   });
 
   it("rejects bids below the tie-break minimum", () => {
@@ -1799,11 +1816,16 @@ describe("applyAction — auction_bid / auction_pass", () => {
       tilePosition: 3,
       amount: 50,
     });
+    expect(settled.state.phase).toBe("waiting_for_auction_settle");
     expect(
       settled.logEntries.some((entry) => entry.actionType === "auction_bid"),
     ).toBe(true);
+    const finalized = finalizeAuctionSettleIfReady(
+      settled.state,
+      settled.state.pendingAuction!.settleDeadlineAt! + 1,
+    );
     expect(
-      settled.logEntries.some(
+      finalized!.logEntries.some(
         (entry) => entry.actionType === "auction_settled",
       ),
     ).toBe(true);
@@ -1823,11 +1845,39 @@ describe("applyAction — auction_bid / auction_pass", () => {
       },
     });
     const closed = closeAuctionBidWindowIfReady(state, Date.now());
-    expect(closed?.state.phase).toBe("action");
-    const winner = closed?.state.players.find(
+    expect(closed?.state.phase).toBe("waiting_for_auction_settle");
+    const finalized = finalizeAuctionSettleIfReady(
+      closed!.state,
+      closed!.state.pendingAuction!.settleDeadlineAt! + 1,
+    );
+    expect(finalized?.state.phase).toBe("action");
+    const winner = finalized?.state.players.find(
       (player) => player.playerId === "player-1",
     );
     expect(winner?.ownedTilePositions).toContain(3);
+    expect(
+      closed!.logEntries.filter(
+        (entry) => entry.actionType === "auction_bids_closed",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("waits for settle delay before revealing bids", () => {
+    const state = makeAuctionState({
+      phase: "waiting_for_auction_settle",
+      pendingAuction: {
+        tilePosition: 3,
+        trigger: "decline",
+        auctionType: "sealed_bids",
+        submissions: { "player-1": 80, "player-2": 50 },
+        eligiblePlayerIds: ["player-1", "player-2"],
+        tieBreakRound: 0,
+        resumePhase: "action",
+        bidDeadlineAt: Date.now() - 1,
+        settleDeadlineAt: Date.now() + 60_000,
+      },
+    });
+    expect(finalizeAuctionSettleIfReady(state, Date.now())).toBeNull();
   });
 
   it("rejects bids after the bid window closes", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the lobby `auctionSettleDelay` setting end-to-end. After the sealed bid window closes, games enter **`waiting_for_auction_settle`** with a countdown before bids are revealed and settled.

## Flow

1. `decline_tile` → `waiting_for_auction_bids` (`bidDeadlineAt`)
2. All players submit OR bid window expires → auto-pass missing bidders → `waiting_for_auction_settle` (`settleDeadlineAt`, log `auction_bids_closed`)
3. Settle delay expires → `finalizeAuctionSettleIfReady` → `auction_settled` (or tie-break → back to step 1)

## Changes

- **Engine (`@oligopoly/shared`)**: `auctionSettleDelayToMs`, `computeAuctionSettleDeadline`, `beginAuctionSettlePhase`, `finalizeAuctionSettleIfReady`; bid close now transitions to settle phase instead of immediate settlement
- **Validation**: new phase `waiting_for_auction_settle`, `settleDeadlineAt` on pending auction, `timerKind: "auction_settle"`
- **Worker**: `syncGameRoomTimer` settle branch, `applyAuctionSettleExpiry`, consolidated auction expiry via `applyAuctionPhaseTransition`
- **Web**: settle-phase UI in `AuctionPanel`, timer label on `GameDetailPage`, `isAuctionBiddingPhase` helper
- **Tests**: unit/integration coverage + `advanceAuctionSettle` harness helper

## Quality fixes

- Fixed duplicate `auction_bids_closed` log entries when closing the bid window (same `logs` array was spread twice)
- Deduplicated worker auction expiry handlers

## Planning docs

Updated `oligopoly_technical_plan.md` § gameplay runtime (auction settle delay). Validated against `oligopoly_game_rules.md` sealed auction + settle delay semantics.

## Verification

- `pnpm run typecheck`
- `pnpm run test:unit` (308)
- `pnpm run test:integration` (140)
- `pnpm run test:e2e` (2)
- `pnpm run lint:fix`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b220472-5252-4354-a7c0-315bebd6b719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b220472-5252-4354-a7c0-315bebd6b719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

