### PR TITLE
Make local two-player lobby flow playable

### DIFF
--- a/oligopoly_dev_guide.md
+++ b/oligopoly_dev_guide.md
@@ -96,10 +96,11 @@ pnpm run dev
 Local multiplayer uses the same Worker, D1/KV, Durable Object, and Vite runtime as online play:
 
 1. Start the stack with `pnpm run dev`.
-2. Open separate browser profiles or private windows for each human player.
+2. Open separate browser profiles or different browsers for each human player. Do not rely on multiple private/incognito windows from the same browser profile because they may share the same local storage session.
 3. Register or seed distinct users, then create a lobby at `http://localhost:5173`.
 4. For solo vs AI, create one human lobby and add at least one AI slot before starting.
-5. For mixed local play, add other local users and optional AI slots, then start the game and keep each browser connected to the game WebSocket.
+5. For mixed local play, add other local users and optional AI slots.
+6. Mark every human player ready, then start the game and keep each browser connected to the game WebSocket.
 
 ### AI player setup
 

--- a/oligopoly_dev_guide.md
+++ b/oligopoly_dev_guide.md
@@ -101,6 +101,20 @@ Local multiplayer uses the same Worker, D1/KV, Durable Object, and Vite runtime 
 4. For solo vs AI, create one human lobby and add at least one AI slot before starting.
 5. For mixed local play, add other local users and optional AI slots, then start the game and keep each browser connected to the game WebSocket.
 
+### AI player setup
+
+AI players work locally with the default deterministic rules engine and do not require an external API key. The rules-based AI is the baseline runtime used for lobby AI seats, turn-timeout takeovers, auction participation, and kicked-player replacements.
+
+To test AI seats locally:
+
+1. Start the stack with `pnpm run dev`.
+2. Sign in, open `http://localhost:5173/lobbies`, and create a lobby.
+3. Set the AI player count in the lobby creation form and choose one personality: `loyalist`, `opportunist`, or `disruptor`.
+4. For solo vs AI, keep exactly one human player and at least one AI slot; for mixed games, keep total human plus AI seats between 2 and 6.
+5. Mark every human player ready and start the lobby. `GameRoom` runs AI turns automatically after game scheduling and game action updates; no client-side AI stepping is needed.
+
+`.env.example` includes `ANTHROPIC_API_KEY`, `ANTHROPIC_DAILY_BUDGET_ALERT`, and `ANTHROPIC_MONTHLY_BUDGET_ALERT` as the reserved contract for optional LLM-assisted AI. Leave those values empty for local deterministic AI. If a deployment adds an Anthropic-backed adapter, set the key and budget limits in that deployment environment; deterministic AI remains the fallback.
+
 ### Validate
 
 ```bash

--- a/oligopoly_technical_plan.md
+++ b/oligopoly_technical_plan.md
@@ -243,7 +243,8 @@ AI player protocol:
 Auth consistency rule:
 
 - Passkey (WebAuthn) is the base authentication mechanism.
-- Session tokens are issued after successful registration or login and sent via `Authorization: Bearer <token>` header.
+- Session tokens are issued after successful registration or login and sent via `Authorization: Bearer <token>` header for HTTP requests.
+- Browser WebSocket clients cannot set custom `Authorization` headers, so authenticated game/lobby WebSocket upgrades may carry the same session token in an `access_token` query parameter. This exception is upgrade-only, must flow through the shared auth middleware before rate-limit/ban checks, and deployment logs/traces must scrub `access_token` values as secrets.
 - The legacy `x-subject` header is still supported for backwards compatibility with integration tests.
 - Challenges are stored in KV with a 5-minute TTL.
 - Sessions are stored in D1 `auth_sessions` table with a 30-day TTL.

--- a/oligopoly_technical_plan.md
+++ b/oligopoly_technical_plan.md
@@ -233,7 +233,7 @@ AI player protocol:
 - `GameRoom` is the sole AI orchestration owner: it schedules turn-timeout alarms from `settings.turnTimeout`, emits `game.timer`, applies timeout takeover on alarm, and auto-runs AI turns via `runAiTurnLoop` after canonical state writes (`game.schedule` or `game.action_applied`).
 - Lobby start and kick replacement persist canonical state and emit `game.schedule` / `game.action_applied`; they do not call `runAiTurnLoop` directly.
 - `DELETE /api/lobbies/:id/player/:uid` during `in_game` replaces the kicked human seat with a permanent AI replacement in the active game state via `kickInGamePlayerToAi`.
-- `POST /api/games/:id/ai/step` remains available for manual/debug stepping only on `/dev`; the play UI does not expose AI stepping and the client does not auto-step AI turns.
+- `POST /api/games/:id/ai/step` remains available for authenticated manual/debug stepping only from local development hosts (`localhost` / `127.0.0.1`); the play UI does not expose AI stepping and the client does not auto-step AI turns.
 - `GameDetailPage` loads board names from `GET /api/game-config`, shows live board/turn state over WebSocket, and exposes the core turn loop (roll, buy/decline, sealed auction bid/pass, path choice, develop/mortgage/redeem, end turn) for the signed-in participant.
 - `GameDetailPage` uses `useGameSession` (HTTP load + `useGameRealtime` for state, log entries, and timers) and renders a perimeter board grid plus player table.
 - All lobby JSON responses route through `buildLobbyResponse`, which attaches optional `gameId` when status is `in_game`.

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -190,7 +190,7 @@ export const GameRealtimeEventSchema = z.discriminatedUnion("type", [
     sentAt: z.number(),
     gameId: z.string(),
     actorId: z.string(),
-    action: GameActionSchema,
+    action: GameActionSchema.optional(),
     logEntries: z.array(GameLogEntrySchema).optional(),
     state: GameStateSchema,
   }),

--- a/packages/validation/src/validationShared.ts
+++ b/packages/validation/src/validationShared.ts
@@ -272,6 +272,7 @@ export const CallsErrorKeys = {
 
 export const GameErrorKeys = {
   AUTH_REQUIRED: "game.auth_required",
+  FORBIDDEN: "game.forbidden",
   NOT_FOUND: "game.not_found",
   NOT_PLAYER: "game.not_player",
   GAME_COMPLETED: "game.completed",
@@ -385,6 +386,24 @@ export const LobbyAiSlotSchema = z.object({
 });
 export type LobbyAiSlot = z.infer<typeof LobbyAiSlotSchema>;
 
+const LobbyAiSlotsSchema = z
+  .array(LobbyAiSlotSchema)
+  .max(5)
+  .superRefine((slots, ctx) => {
+    const seen = new Set<string>();
+    slots.forEach((slot, index) => {
+      if (seen.has(slot.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "AI slot IDs must be unique",
+          path: [index, "id"],
+        });
+        return;
+      }
+      seen.add(slot.id);
+    });
+  });
+
 export const GamePlayerKindSchema = z.enum(["human", "ai"]);
 export type GamePlayerKind = z.infer<typeof GamePlayerKindSchema>;
 
@@ -415,7 +434,7 @@ export const CreateLobbyInputSchema = z.object({
   maxPlayers: z.number().int().min(2).max(6),
   isPrivate: z.boolean(),
   optionalRuleIds: z.array(z.string()).default([]),
-  aiSlots: z.array(LobbyAiSlotSchema).max(5).default([]),
+  aiSlots: LobbyAiSlotsSchema.default([]),
   turnTimeout: TurnTimeoutSchema.default("5min"),
   auctionBidWindow: z
     .enum(["30s", "1min", "5min", "10min", "30min"])
@@ -438,7 +457,7 @@ export const UpdateLobbySettingsInputSchema = z.object({
   maxPlayers: z.number().int().min(2).max(6).optional(),
   isPrivate: z.boolean().optional(),
   optionalRuleIds: z.array(z.string()).optional(),
-  aiSlots: z.array(LobbyAiSlotSchema).max(5).optional(),
+  aiSlots: LobbyAiSlotsSchema.optional(),
   turnTimeout: TurnTimeoutSchema.optional(),
   auctionBidWindow: z
     .enum(["30s", "1min", "5min", "10min", "30min"])

--- a/packages/web/src/api/games.test.ts
+++ b/packages/web/src/api/games.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { storeToken } from "./auth";
+import { gameWebSocketUrl } from "./games";
+
+describe("gameWebSocketUrl", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("adds the stored token for participant sockets", () => {
+    storeToken("game-token");
+
+    expect(gameWebSocketUrl("game-1")).toBe(
+      "ws://localhost:8787/api/games/game-1/ws?access_token=game-token",
+    );
+  });
+
+  it("does not add a token for spectator sockets", () => {
+    storeToken("game-token");
+
+    expect(gameWebSocketUrl("game-1", true)).toBe(
+      "ws://localhost:8787/api/games/game-1/spectate",
+    );
+  });
+});

--- a/packages/web/src/api/games.ts
+++ b/packages/web/src/api/games.ts
@@ -79,5 +79,12 @@ export function stepAiTurn(id: string) {
 
 export function gameWebSocketUrl(id: string, spectator = false) {
   const path = spectator ? "spectate" : "ws";
-  return `${env.wsUrl}/api/games/${encodeURIComponent(id)}/${path}`;
+  const url = new URL(
+    `${env.wsUrl}/api/games/${encodeURIComponent(id)}/${path}`,
+  );
+  const token = spectator ? null : getStoredToken();
+  if (token) {
+    url.searchParams.set("access_token", token);
+  }
+  return url.toString();
 }

--- a/packages/web/src/api/lobbies.test.ts
+++ b/packages/web/src/api/lobbies.test.ts
@@ -5,6 +5,7 @@ import {
   createLobby,
   leaveLobby,
   listMyLobbies,
+  lobbyWebSocketUrl,
 } from "./lobbies";
 
 const lobbyResponse = {

--- a/packages/web/src/api/lobbies.ts
+++ b/packages/web/src/api/lobbies.ts
@@ -134,5 +134,12 @@ export function clearLobbyReady(lobbyId: string) {
 }
 
 export function lobbyWebSocketUrl(lobbyId: string) {
-  return `${env.wsUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/ws`;
+  const url = new URL(
+    `${env.wsUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/ws`,
+  );
+  const token = getStoredToken();
+  if (token) {
+    url.searchParams.set("access_token", token);
+  }
+  return url.toString();
 }

--- a/packages/web/src/api/lobbies.ts
+++ b/packages/web/src/api/lobbies.ts
@@ -4,7 +4,6 @@ import {
   LobbiesListResponseSchema,
   LobbyInviteResponseSchema,
   LobbyResponseSchema,
-  type LobbyStatus,
   StartLobbyResponseSchema,
 } from "@oligopoly/validation";
 import type { z } from "zod";
@@ -132,4 +131,8 @@ export function clearLobbyReady(lobbyId: string) {
       headers: authHeaders(),
     },
   );
+}
+
+export function lobbyWebSocketUrl(lobbyId: string) {
+  return `${env.wsUrl}/api/lobbies/${encodeURIComponent(lobbyId)}/ws`;
 }

--- a/packages/web/src/hooks/useGameRealtime.ts
+++ b/packages/web/src/hooks/useGameRealtime.ts
@@ -3,8 +3,9 @@ import {
   GameRealtimeEventSchema,
   GameStateSchema,
 } from "@oligopoly/validation";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { gameWebSocketUrl } from "../api/games";
+import { useRealtimeChannel } from "./useRealtimeChannel";
 
 export type GameSessionUpdate = {
   state: GameState;
@@ -20,69 +21,46 @@ export function useGameRealtime(
   gameId: string | undefined,
   options: UseGameRealtimeOptions = {},
 ) {
-  const [wsStatus, setWsStatus] = useState("disconnected");
   const [turnDeadline, setTurnDeadline] = useState<number | null>(null);
   const [timerKind, setTimerKind] = useState<
     "turn" | "auction_bids" | "auction_settle"
   >("turn");
-  const onUpdateRef = useRef(options.onUpdate);
-  onUpdateRef.current = options.onUpdate;
 
-  useEffect(() => {
-    if (!gameId) {
-      setWsStatus("disconnected");
-      setTurnDeadline(null);
-      return;
-    }
-
-    setWsStatus("connecting");
-    const socket = new WebSocket(gameWebSocketUrl(gameId));
-    socket.onopen = () => setWsStatus("connected");
-    socket.onclose = () => setWsStatus("disconnected");
-    socket.onerror = () => setWsStatus("error");
-    socket.onmessage = (event) => {
-      try {
-        const parsed = GameRealtimeEventSchema.safeParse(
-          JSON.parse(String(event.data)),
-        );
-        if (!parsed.success) return;
-
-        const message = parsed.data;
-        if (message.type === "game.action_applied" && "state" in message) {
-          onUpdateRef.current?.({
-            state: GameStateSchema.parse(message.state),
-            logEntries: message.logEntries,
-            source: "Realtime state update",
-          });
-          return;
-        }
-        if (message.type === "game.schedule" && "state" in message) {
-          onUpdateRef.current?.({
-            state: GameStateSchema.parse(message.state),
-            source: "Realtime schedule update",
-          });
-          return;
-        }
-        if (message.type === "game.snapshot" && "payload" in message) {
-          onUpdateRef.current?.({
-            state: GameStateSchema.parse(message.payload),
-            source: "Realtime snapshot",
-          });
-          return;
-        }
-        if (message.type === "game.timer" && "deadlineAt" in message) {
-          setTurnDeadline(message.deadlineAt ?? null);
-          if (message.timerKind) {
-            setTimerKind(message.timerKind);
-          }
-        }
-      } catch {
-        // Ignore malformed websocket payloads.
+  const { wsStatus } = useRealtimeChannel({
+    url: gameId ? gameWebSocketUrl(gameId) : undefined,
+    schema: GameRealtimeEventSchema,
+    onDisconnect: () => setTurnDeadline(null),
+    onMessage: (message) => {
+      if (message.type === "game.action_applied" && "state" in message) {
+        options.onUpdate?.({
+          state: GameStateSchema.parse(message.state),
+          logEntries: message.logEntries,
+          source: "Realtime state update",
+        });
+        return;
       }
-    };
-
-    return () => socket.close();
-  }, [gameId]);
+      if (message.type === "game.schedule" && "state" in message) {
+        options.onUpdate?.({
+          state: GameStateSchema.parse(message.state),
+          source: "Realtime schedule update",
+        });
+        return;
+      }
+      if (message.type === "game.snapshot" && "payload" in message) {
+        options.onUpdate?.({
+          state: GameStateSchema.parse(message.payload),
+          source: "Realtime snapshot",
+        });
+        return;
+      }
+      if (message.type === "game.timer" && "deadlineAt" in message) {
+        setTurnDeadline(message.deadlineAt ?? null);
+        if (message.timerKind) {
+          setTimerKind(message.timerKind);
+        }
+      }
+    },
+  });
 
   return { wsStatus, turnDeadline, timerKind };
 }

--- a/packages/web/src/hooks/useGameSession.ts
+++ b/packages/web/src/hooks/useGameSession.ts
@@ -61,12 +61,6 @@ export function useGameSession(
 
   const applySessionUpdate = useCallback(
     (update: GameSessionUpdate) => {
-      setState((current) => mergeRedactedGameSnapshot(current, update.state));
-      if (update.logEntries?.length) {
-        setLogEntries((current) =>
-          appendLogEntries(current, update.logEntries),
-        );
-      }
       setStatusLine(update.source);
 
       if (gameId && update.source.startsWith("Realtime")) {
@@ -78,8 +72,16 @@ export function useGameSession(
             setLogEntries(log);
           })
           .catch(() => {
-            // Keep the realtime snapshot visible if the authenticated refresh fails.
+            // Keep the current state visible if the authenticated refresh fails.
           });
+        return;
+      }
+
+      setState((current) => mergeRedactedGameSnapshot(current, update.state));
+      if (update.logEntries?.length) {
+        setLogEntries((current) =>
+          appendLogEntries(current, update.logEntries),
+        );
       }
     },
     [gameId],

--- a/packages/web/src/hooks/useGameSession.ts
+++ b/packages/web/src/hooks/useGameSession.ts
@@ -59,13 +59,29 @@ export function useGameSession(
   const [busyAction, setBusyAction] = useState(false);
   const [statusLine, setStatusLine] = useState<string | null>(null);
 
-  const applySessionUpdate = useCallback((update: GameSessionUpdate) => {
-    setState((current) => mergeAuctionClientView(current, update.state));
-    if (update.logEntries?.length) {
-      setLogEntries((current) => appendLogEntries(current, update.logEntries));
-    }
-    setStatusLine(update.source);
-  }, []);
+  const applySessionUpdate = useCallback(
+    (update: GameSessionUpdate) => {
+      setState((current) => mergeAuctionClientView(current, update.state));
+      if (update.logEntries?.length) {
+        setLogEntries((current) =>
+          appendLogEntries(current, update.logEntries),
+        );
+      }
+      setStatusLine(update.source);
+
+      if (gameId && update.source.startsWith("Realtime")) {
+        void Promise.all([fetchGameState(gameId), loadGameLog(gameId)])
+          .then(([gameState, log]) => {
+            setState((current) => mergeAuctionClientView(current, gameState));
+            setLogEntries(log);
+          })
+          .catch(() => {
+            // Keep the realtime snapshot visible if the authenticated refresh fails.
+          });
+      }
+    },
+    [gameId],
+  );
 
   const { wsStatus, turnDeadline, timerKind } = useGameRealtime(gameId, {
     onUpdate: applySessionUpdate,

--- a/packages/web/src/hooks/useGameSession.ts
+++ b/packages/web/src/hooks/useGameSession.ts
@@ -17,7 +17,7 @@ import { buildTileNameMap } from "../lib/boardDisplay";
 import {
   currentActorId,
   isMyTurn,
-  mergeRedactedGameSnapshot,
+  mergeAuctionClientView,
 } from "../lib/gameUi";
 import { type GameSessionUpdate, useGameRealtime } from "./useGameRealtime";
 
@@ -59,33 +59,13 @@ export function useGameSession(
   const [busyAction, setBusyAction] = useState(false);
   const [statusLine, setStatusLine] = useState<string | null>(null);
 
-  const applySessionUpdate = useCallback(
-    (update: GameSessionUpdate) => {
-      setStatusLine(update.source);
-
-      if (gameId && update.source.startsWith("Realtime")) {
-        void Promise.all([fetchGameState(gameId), loadGameLog(gameId)])
-          .then(([gameState, log]) => {
-            setState((current) =>
-              mergeRedactedGameSnapshot(current, gameState),
-            );
-            setLogEntries(log);
-          })
-          .catch(() => {
-            // Keep the current state visible if the authenticated refresh fails.
-          });
-        return;
-      }
-
-      setState((current) => mergeRedactedGameSnapshot(current, update.state));
-      if (update.logEntries?.length) {
-        setLogEntries((current) =>
-          appendLogEntries(current, update.logEntries),
-        );
-      }
-    },
-    [gameId],
-  );
+  const applySessionUpdate = useCallback((update: GameSessionUpdate) => {
+    setState((current) => mergeAuctionClientView(current, update.state));
+    if (update.logEntries?.length) {
+      setLogEntries((current) => appendLogEntries(current, update.logEntries));
+    }
+    setStatusLine(update.source);
+  }, []);
 
   const { wsStatus, turnDeadline, timerKind } = useGameRealtime(gameId, {
     onUpdate: applySessionUpdate,

--- a/packages/web/src/hooks/useGameSession.ts
+++ b/packages/web/src/hooks/useGameSession.ts
@@ -17,7 +17,7 @@ import { buildTileNameMap } from "../lib/boardDisplay";
 import {
   currentActorId,
   isMyTurn,
-  mergeAuctionClientView,
+  mergeRedactedGameSnapshot,
 } from "../lib/gameUi";
 import { type GameSessionUpdate, useGameRealtime } from "./useGameRealtime";
 
@@ -61,7 +61,7 @@ export function useGameSession(
 
   const applySessionUpdate = useCallback(
     (update: GameSessionUpdate) => {
-      setState((current) => mergeAuctionClientView(current, update.state));
+      setState((current) => mergeRedactedGameSnapshot(current, update.state));
       if (update.logEntries?.length) {
         setLogEntries((current) =>
           appendLogEntries(current, update.logEntries),
@@ -72,7 +72,9 @@ export function useGameSession(
       if (gameId && update.source.startsWith("Realtime")) {
         void Promise.all([fetchGameState(gameId), loadGameLog(gameId)])
           .then(([gameState, log]) => {
-            setState((current) => mergeAuctionClientView(current, gameState));
+            setState((current) =>
+              mergeRedactedGameSnapshot(current, gameState),
+            );
             setLogEntries(log);
           })
           .catch(() => {

--- a/packages/web/src/hooks/useLobbyRealtime.ts
+++ b/packages/web/src/hooks/useLobbyRealtime.ts
@@ -1,0 +1,70 @@
+import type { LobbyResponse } from "@oligopoly/validation";
+import {
+  LobbyRealtimeEventSchema,
+  LobbyResponseSchema,
+} from "@oligopoly/validation";
+import { useEffect, useRef, useState } from "react";
+import { lobbyWebSocketUrl } from "../api/lobbies";
+
+export type LobbyRealtimeUpdate = {
+  lobby: LobbyResponse;
+  source: string;
+};
+
+type UseLobbyRealtimeOptions = {
+  onUpdate?: (update: LobbyRealtimeUpdate) => void;
+};
+
+export function useLobbyRealtime(
+  lobbyId: string | undefined,
+  options: UseLobbyRealtimeOptions = {},
+) {
+  const [wsStatus, setWsStatus] = useState("disconnected");
+  const onUpdateRef = useRef(options.onUpdate);
+  onUpdateRef.current = options.onUpdate;
+
+  useEffect(() => {
+    if (!lobbyId) {
+      setWsStatus("disconnected");
+      return;
+    }
+
+    setWsStatus("connecting");
+    const socket = new WebSocket(lobbyWebSocketUrl(lobbyId));
+    socket.onopen = () => setWsStatus("connected");
+    socket.onclose = () => setWsStatus("disconnected");
+    socket.onerror = () => setWsStatus("error");
+    socket.onmessage = (event) => {
+      try {
+        const parsed = LobbyRealtimeEventSchema.safeParse(
+          JSON.parse(String(event.data)),
+        );
+        if (!parsed.success) return;
+
+        const message = parsed.data;
+        if (
+          (message.type === "lobby.snapshot" ||
+            message.type === "lobby.updated") &&
+          "payload" in message
+        ) {
+          const lobby = LobbyResponseSchema.safeParse(message.payload);
+          if (!lobby.success) return;
+
+          onUpdateRef.current?.({
+            lobby: { ...lobby.data, aiSlots: lobby.data.aiSlots ?? [] },
+            source:
+              message.type === "lobby.snapshot"
+                ? "Realtime lobby snapshot"
+                : "Realtime lobby update",
+          });
+        }
+      } catch {
+        // Ignore malformed websocket payloads.
+      }
+    };
+
+    return () => socket.close();
+  }, [lobbyId]);
+
+  return { wsStatus };
+}

--- a/packages/web/src/hooks/useLobbyRealtime.ts
+++ b/packages/web/src/hooks/useLobbyRealtime.ts
@@ -3,8 +3,8 @@ import {
   LobbyRealtimeEventSchema,
   LobbyResponseSchema,
 } from "@oligopoly/validation";
-import { useEffect, useRef, useState } from "react";
 import { lobbyWebSocketUrl } from "../api/lobbies";
+import { useRealtimeChannel } from "./useRealtimeChannel";
 
 export type LobbyRealtimeUpdate = {
   lobby: LobbyResponse;
@@ -19,52 +19,26 @@ export function useLobbyRealtime(
   lobbyId: string | undefined,
   options: UseLobbyRealtimeOptions = {},
 ) {
-  const [wsStatus, setWsStatus] = useState("disconnected");
-  const onUpdateRef = useRef(options.onUpdate);
-  onUpdateRef.current = options.onUpdate;
+  return useRealtimeChannel({
+    url: lobbyId ? lobbyWebSocketUrl(lobbyId) : undefined,
+    schema: LobbyRealtimeEventSchema,
+    onMessage: (message) => {
+      if (
+        (message.type === "lobby.snapshot" ||
+          message.type === "lobby.updated") &&
+        "payload" in message
+      ) {
+        const lobby = LobbyResponseSchema.safeParse(message.payload);
+        if (!lobby.success) return;
 
-  useEffect(() => {
-    if (!lobbyId) {
-      setWsStatus("disconnected");
-      return;
-    }
-
-    setWsStatus("connecting");
-    const socket = new WebSocket(lobbyWebSocketUrl(lobbyId));
-    socket.onopen = () => setWsStatus("connected");
-    socket.onclose = () => setWsStatus("disconnected");
-    socket.onerror = () => setWsStatus("error");
-    socket.onmessage = (event) => {
-      try {
-        const parsed = LobbyRealtimeEventSchema.safeParse(
-          JSON.parse(String(event.data)),
-        );
-        if (!parsed.success) return;
-
-        const message = parsed.data;
-        if (
-          (message.type === "lobby.snapshot" ||
-            message.type === "lobby.updated") &&
-          "payload" in message
-        ) {
-          const lobby = LobbyResponseSchema.safeParse(message.payload);
-          if (!lobby.success) return;
-
-          onUpdateRef.current?.({
-            lobby: { ...lobby.data, aiSlots: lobby.data.aiSlots ?? [] },
-            source:
-              message.type === "lobby.snapshot"
-                ? "Realtime lobby snapshot"
-                : "Realtime lobby update",
-          });
-        }
-      } catch {
-        // Ignore malformed websocket payloads.
+        options.onUpdate?.({
+          lobby: lobby.data,
+          source:
+            message.type === "lobby.snapshot"
+              ? "Realtime lobby snapshot"
+              : "Realtime lobby update",
+        });
       }
-    };
-
-    return () => socket.close();
-  }, [lobbyId]);
-
-  return { wsStatus };
+    },
+  });
 }

--- a/packages/web/src/hooks/useRealtimeChannel.ts
+++ b/packages/web/src/hooks/useRealtimeChannel.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from "react";
+import type { ZodType } from "zod";
+
+type UseRealtimeChannelOptions<TEvent> = {
+  url: string | undefined;
+  schema: ZodType<TEvent>;
+  onMessage: (message: TEvent) => void;
+  onDisconnect?: () => void;
+};
+
+export function useRealtimeChannel<TEvent>({
+  url,
+  schema,
+  onMessage,
+  onDisconnect,
+}: UseRealtimeChannelOptions<TEvent>) {
+  const [wsStatus, setWsStatus] = useState("disconnected");
+  const onMessageRef = useRef(onMessage);
+  const onDisconnectRef = useRef(onDisconnect);
+  onMessageRef.current = onMessage;
+  onDisconnectRef.current = onDisconnect;
+
+  useEffect(() => {
+    if (!url) {
+      setWsStatus("disconnected");
+      onDisconnectRef.current?.();
+      return;
+    }
+
+    setWsStatus("connecting");
+    const socket = new WebSocket(url);
+    socket.onopen = () => setWsStatus("connected");
+    socket.onclose = () => {
+      setWsStatus("disconnected");
+      onDisconnectRef.current?.();
+    };
+    socket.onerror = () => setWsStatus("error");
+    socket.onmessage = (event) => {
+      try {
+        const parsed = schema.safeParse(JSON.parse(String(event.data)));
+        if (parsed.success) {
+          onMessageRef.current(parsed.data);
+        }
+      } catch {
+        // Ignore malformed websocket payloads.
+      }
+    };
+
+    return () => socket.close();
+  }, [schema, url]);
+
+  return { wsStatus };
+}

--- a/packages/web/src/lib/gameUi.ts
+++ b/packages/web/src/lib/gameUi.ts
@@ -102,11 +102,8 @@ export function hasSubmittedAuction(
   return state.pendingAuction.mySubmission !== undefined;
 }
 
-/**
- * Broadcast WS snapshots omit viewer-specific auction fields. Preserve the
- * local player's sealed submission until settlement or a tie-break reset.
- */
-export function mergeAuctionClientView(
+/** Merge broadcast-safe realtime snapshots with viewer-only fields already loaded over authenticated HTTP. */
+export function mergeRedactedGameSnapshot(
   previous: GameState | null,
   incoming: GameState,
 ): GameState {

--- a/packages/web/src/lib/gameUi.ts
+++ b/packages/web/src/lib/gameUi.ts
@@ -131,6 +131,19 @@ export function mergeAuctionClientView(
     };
   }
 
+  const previousPrivateThreads = previous?.negotiationThreads?.filter(
+    (thread) => thread.visibility !== "open",
+  );
+  const incomingThreadIds = new Set(
+    incoming.negotiationThreads?.map((thread) => thread.id) ?? [],
+  );
+  const preservedPrivateThreads = previousPrivateThreads?.filter(
+    (thread) => !incomingThreadIds.has(thread.id),
+  );
+  const negotiationThreads = incoming.negotiationThreads
+    ? [...incoming.negotiationThreads, ...(preservedPrivateThreads ?? [])]
+    : previous?.negotiationThreads;
+
   return {
     ...merged,
     ...(previous?.myAffinityCardId !== undefined &&
@@ -145,10 +158,7 @@ export function mergeAuctionClientView(
     incoming.handshakeAgreements === undefined
       ? { handshakeAgreements: previous.handshakeAgreements }
       : {}),
-    ...(previous?.negotiationThreads &&
-    incoming.negotiationThreads === undefined
-      ? { negotiationThreads: previous.negotiationThreads }
-      : {}),
+    ...(negotiationThreads ? { negotiationThreads } : {}),
   };
 }
 

--- a/packages/web/src/lib/gameUi.ts
+++ b/packages/web/src/lib/gameUi.ts
@@ -110,32 +110,45 @@ export function mergeAuctionClientView(
   previous: GameState | null,
   incoming: GameState,
 ): GameState {
+  let merged = incoming;
   const prevAuction = previous?.pendingAuction;
   const nextAuction = incoming.pendingAuction;
   if (
-    !prevAuction?.mySubmission ||
-    !nextAuction ||
-    nextAuction.auctionType === "open_bids" ||
-    nextAuction.auctionType === "live_bidding"
+    prevAuction?.mySubmission &&
+    nextAuction &&
+    nextAuction.auctionType !== "open_bids" &&
+    nextAuction.auctionType !== "live_bidding" &&
+    nextAuction.mySubmission === undefined &&
+    String(prevAuction.tilePosition) === String(nextAuction.tilePosition) &&
+    (prevAuction.tieBreakRound ?? 0) === (nextAuction.tieBreakRound ?? 0)
   ) {
-    return incoming;
-  }
-  if (nextAuction.mySubmission !== undefined) {
-    return incoming;
-  }
-  if (
-    String(prevAuction.tilePosition) !== String(nextAuction.tilePosition) ||
-    (prevAuction.tieBreakRound ?? 0) !== (nextAuction.tieBreakRound ?? 0)
-  ) {
-    return incoming;
+    merged = {
+      ...merged,
+      pendingAuction: {
+        ...nextAuction,
+        mySubmission: prevAuction.mySubmission,
+      },
+    };
   }
 
   return {
-    ...incoming,
-    pendingAuction: {
-      ...nextAuction,
-      mySubmission: prevAuction.mySubmission,
-    },
+    ...merged,
+    ...(previous?.myAffinityCardId !== undefined &&
+    incoming.myAffinityCardId === undefined
+      ? { myAffinityCardId: previous.myAffinityCardId }
+      : {}),
+    ...(previous?.pendingInsiderPeek &&
+    incoming.pendingInsiderPeek === undefined
+      ? { pendingInsiderPeek: previous.pendingInsiderPeek }
+      : {}),
+    ...(previous?.handshakeAgreements &&
+    incoming.handshakeAgreements === undefined
+      ? { handshakeAgreements: previous.handshakeAgreements }
+      : {}),
+    ...(previous?.negotiationThreads &&
+    incoming.negotiationThreads === undefined
+      ? { negotiationThreads: previous.negotiationThreads }
+      : {}),
   };
 }
 

--- a/packages/web/src/lib/gameUi.ts
+++ b/packages/web/src/lib/gameUi.ts
@@ -103,59 +103,36 @@ export function hasSubmittedAuction(
 }
 
 /** Merge broadcast-safe realtime snapshots with viewer-only fields already loaded over authenticated HTTP. */
-export function mergeRedactedGameSnapshot(
+export function mergeAuctionClientView(
   previous: GameState | null,
   incoming: GameState,
 ): GameState {
-  let merged = incoming;
   const prevAuction = previous?.pendingAuction;
   const nextAuction = incoming.pendingAuction;
   if (
-    prevAuction?.mySubmission &&
-    nextAuction &&
-    nextAuction.auctionType !== "open_bids" &&
-    nextAuction.auctionType !== "live_bidding" &&
-    nextAuction.mySubmission === undefined &&
-    String(prevAuction.tilePosition) === String(nextAuction.tilePosition) &&
-    (prevAuction.tieBreakRound ?? 0) === (nextAuction.tieBreakRound ?? 0)
+    !prevAuction?.mySubmission ||
+    !nextAuction ||
+    nextAuction.auctionType === "open_bids" ||
+    nextAuction.auctionType === "live_bidding"
   ) {
-    merged = {
-      ...merged,
-      pendingAuction: {
-        ...nextAuction,
-        mySubmission: prevAuction.mySubmission,
-      },
-    };
+    return incoming;
+  }
+  if (nextAuction.mySubmission !== undefined) {
+    return incoming;
+  }
+  if (
+    String(prevAuction.tilePosition) !== String(nextAuction.tilePosition) ||
+    (prevAuction.tieBreakRound ?? 0) !== (nextAuction.tieBreakRound ?? 0)
+  ) {
+    return incoming;
   }
 
-  const previousPrivateThreads = previous?.negotiationThreads?.filter(
-    (thread) => thread.visibility !== "open",
-  );
-  const incomingThreadIds = new Set(
-    incoming.negotiationThreads?.map((thread) => thread.id) ?? [],
-  );
-  const preservedPrivateThreads = previousPrivateThreads?.filter(
-    (thread) => !incomingThreadIds.has(thread.id),
-  );
-  const negotiationThreads = incoming.negotiationThreads
-    ? [...incoming.negotiationThreads, ...(preservedPrivateThreads ?? [])]
-    : previous?.negotiationThreads;
-
   return {
-    ...merged,
-    ...(previous?.myAffinityCardId !== undefined &&
-    incoming.myAffinityCardId === undefined
-      ? { myAffinityCardId: previous.myAffinityCardId }
-      : {}),
-    ...(previous?.pendingInsiderPeek &&
-    incoming.pendingInsiderPeek === undefined
-      ? { pendingInsiderPeek: previous.pendingInsiderPeek }
-      : {}),
-    ...(previous?.handshakeAgreements &&
-    incoming.handshakeAgreements === undefined
-      ? { handshakeAgreements: previous.handshakeAgreements }
-      : {}),
-    ...(negotiationThreads ? { negotiationThreads } : {}),
+    ...incoming,
+    pendingAuction: {
+      ...nextAuction,
+      mySubmission: prevAuction.mySubmission,
+    },
   };
 }
 

--- a/packages/web/src/pages/LobbiesPage.test.tsx
+++ b/packages/web/src/pages/LobbiesPage.test.tsx
@@ -145,7 +145,9 @@ describe("LobbiesPage", () => {
 
     await screen.findByText(/no public lobbies available/i);
 
-    fireEvent.click(screen.getByLabelText(/private lobby/i));
+    fireEvent.change(screen.getByLabelText(/lobby visibility/i), {
+      target: { value: "private" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /create lobby/i }));
 
     await waitFor(() => {

--- a/packages/web/src/pages/LobbiesPage.test.tsx
+++ b/packages/web/src/pages/LobbiesPage.test.tsx
@@ -266,6 +266,42 @@ describe("LobbiesPage", () => {
     expect(mockedJoinLobbyWithToken).not.toHaveBeenCalled();
   });
 
+  it("clears a stale invite token when a raw lobby ID is typed manually", async () => {
+    mockedJoinLobby.mockResolvedValue({
+      ...baseLobby,
+      id: "manual-public-lobby",
+      players: [
+        ...baseLobby.players,
+        { userId: "user-2", isAdmin: false, joinedAt: 2 },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LobbiesPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/no public lobbies available/i);
+
+    fireEvent.change(screen.getByLabelText(/invite token/i), {
+      target: { value: "stale-token" },
+    });
+    expect(screen.getByLabelText(/invite token/i)).toHaveValue("stale-token");
+
+    fireEvent.change(screen.getByLabelText(/lobby id or invite link/i), {
+      target: { value: "manual-public-lobby" },
+    });
+    expect(screen.getByLabelText(/invite token/i)).toHaveValue("");
+
+    fireEvent.click(screen.getByRole("button", { name: /join lobby/i }));
+
+    await waitFor(() => {
+      expect(mockedJoinLobby).toHaveBeenCalledWith("manual-public-lobby");
+    });
+    expect(mockedJoinLobbyWithToken).not.toHaveBeenCalled();
+  });
+
   it("shows the signed-in user's waiting lobbies and enforces the 2-lobby limit in the UI", async () => {
     mockedListMyLobbies.mockResolvedValue({
       lobbies: [

--- a/packages/web/src/pages/LobbiesPage.test.tsx
+++ b/packages/web/src/pages/LobbiesPage.test.tsx
@@ -9,6 +9,10 @@ vi.mock("../components/AuthContext", () => ({
   useAuth: vi.fn(),
 }));
 
+vi.mock("../hooks/useLobbyRealtime", () => ({
+  useLobbyRealtime: () => ({ wsStatus: "disconnected" }),
+}));
+
 vi.mock("../api/lobbies", async () => {
   const actual =
     await vi.importActual<typeof import("../api/lobbies")>("../api/lobbies");
@@ -43,6 +47,7 @@ const mockedUseAuth = vi.mocked(useAuth);
 const mockedCreateLobby = vi.mocked(lobbyApi.createLobby);
 const mockedCreateInviteToken = vi.mocked(lobbyApi.createInviteToken);
 const mockedFetchLobby = vi.mocked(lobbyApi.fetchLobby);
+const mockedJoinLobby = vi.mocked(lobbyApi.joinLobby);
 const mockedJoinLobbyWithToken = vi.mocked(lobbyApi.joinLobbyWithToken);
 const mockedLeaveLobby = vi.mocked(lobbyApi.leaveLobby);
 const mockedListMyLobbies = vi.mocked(lobbyApi.listMyLobbies);
@@ -153,8 +158,8 @@ describe("LobbiesPage", () => {
     expect(
       screen.getAllByText(/you are in this lobby as an admin/i),
     ).toHaveLength(2);
-    expect(screen.getByRole("listitem")).toHaveTextContent(
-      "user-1 (you, admin)",
+    expect(screen.getAllByRole("listitem")[0]).toHaveTextContent(
+      "user-1 (you, admin, not ready)",
     );
 
     fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
@@ -201,6 +206,62 @@ describe("LobbiesPage", () => {
       "shared-lobby",
     );
     expect(screen.getByLabelText(/invite token/i)).toHaveValue("invite-join");
+  });
+
+  it("joins a selected public lobby directly when the invite token field is stale", async () => {
+    mockedUseAuth.mockReturnValue({
+      user: {
+        userId: "viewer-1",
+        username: "viewer",
+        expiresAt: Date.now() + 60_000,
+      },
+      loading: false,
+      login: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      refresh: vi.fn().mockResolvedValue(undefined),
+    });
+    const publicLobby = {
+      ...baseLobby,
+      id: "public-lobby",
+      name: "Public Lobby",
+      isPrivate: false,
+    };
+    mockedListPublicLobbies.mockResolvedValue({
+      lobbies: [publicLobby],
+      nextCursor: null,
+    });
+    mockedFetchLobby.mockResolvedValue(publicLobby);
+    mockedJoinLobby.mockResolvedValue({
+      ...publicLobby,
+      players: [
+        ...publicLobby.players,
+        { userId: "viewer-1", isAdmin: false, joinedAt: 2 },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LobbiesPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Public Lobby")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/invite token/i), {
+      target: { value: "stale-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/invite token/i)).toHaveValue("");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /join lobby/i }));
+
+    await waitFor(() => {
+      expect(mockedJoinLobby).toHaveBeenCalledWith("public-lobby");
+    });
+    expect(mockedJoinLobbyWithToken).not.toHaveBeenCalled();
   });
 
   it("shows the signed-in user's waiting lobbies and enforces the 2-lobby limit in the UI", async () => {

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -300,6 +300,24 @@ export function LobbiesPage() {
   }, [myLobbies, selectedLobby]);
 
   useEffect(() => {
+    if (!selectedLobby?.id || selectedLobby.status !== "waiting") {
+      return;
+    }
+
+    const intervalId = window.setInterval(async () => {
+      try {
+        applySelectedLobbyUpdate(
+          normalizeLobby(await fetchLobby(selectedLobby.id)),
+        );
+      } catch {
+        // Keep the current lobby visible if a transient refresh fails.
+      }
+    }, 2_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [applySelectedLobbyUpdate, selectedLobby?.id, selectedLobby?.status]);
+
+  useEffect(() => {
     setCreateAiCount((count) => Math.min(count, createMaxPlayers - 1));
   }, [createMaxPlayers]);
 

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -1,5 +1,5 @@
 import { LobbyErrorKeys, type LobbyResponse } from "@oligopoly/validation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Link,
   useLocation,
@@ -21,6 +21,7 @@ import {
 import { useAuth } from "../components/AuthContext";
 import { LobbyAiSettings } from "../components/LobbyAiSettings";
 import { LobbyReadyControls } from "../components/LobbyReadyControls";
+import { useLobbyRealtime } from "../hooks/useLobbyRealtime";
 import { canStartLobby, lobbySeatCount } from "../lib/lobbySeats";
 
 const DEFAULT_MAX_PLAYERS = 4;
@@ -137,12 +138,22 @@ export function LobbiesPage() {
   const [busyLeave, setBusyLeave] = useState(false);
   const [busyStart, setBusyStart] = useState(false);
   const [message, setMessage] = useState<Message>(null);
+  const selectedLobbyCardRef = useRef<HTMLDivElement | null>(null);
 
   const selectedLobbyId = selectedLobby?.id ?? joinLobbyId;
   const resolvedJoinInput = useMemo(
     () => resolveLobbyJoinInput(joinLobbyId, joinToken),
     [joinLobbyId, joinToken],
   );
+
+  const revealSelectedLobby = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      selectedLobbyCardRef.current?.scrollIntoView?.({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  }, []);
 
   const refreshPublicLobbies = useCallback(async () => {
     setLoadingPublicLobbies(true);
@@ -193,6 +204,9 @@ export function LobbiesPage() {
       const lobby = await fetchLobby(id);
       setSelectedLobby(normalizeLobby(lobby));
       setJoinLobbyId(lobby.id);
+      if (!lobby.isPrivate) {
+        setJoinToken("");
+      }
     } catch (error) {
       if (error instanceof ApiError && error.status === 404) {
         setSelectedLobby(null);
@@ -208,6 +222,38 @@ export function LobbiesPage() {
       });
     }
   }, []);
+
+  const applySelectedLobbyUpdate = useCallback(
+    (lobby: LobbyResponse) => {
+      const normalized = normalizeLobby(lobby);
+      setSelectedLobby(normalized);
+      setJoinLobbyId(normalized.id);
+      if (!normalized.isPrivate) {
+        setJoinToken("");
+      }
+      setMyLobbies((current) => {
+        if (!current.some((candidate) => candidate.id === normalized.id)) {
+          return current;
+        }
+        return current.map((candidate) =>
+          candidate.id === normalized.id ? normalized : candidate,
+        );
+      });
+
+      if (
+        normalized.status === "in_game" &&
+        normalized.gameId &&
+        normalized.players.some((player) => player.userId === user?.userId)
+      ) {
+        navigate(`/games/${normalized.gameId}`);
+      }
+    },
+    [navigate, user?.userId],
+  );
+
+  const { wsStatus: lobbyWsStatus } = useLobbyRealtime(selectedLobby?.id, {
+    onUpdate: ({ lobby }) => applySelectedLobbyUpdate(lobby),
+  });
 
   useEffect(() => {
     void refreshPublicLobbies();
@@ -239,6 +285,19 @@ export function LobbiesPage() {
 
     void refreshMyLobbies();
   }, [loading, refreshMyLobbies, user]);
+
+  useEffect(() => {
+    if (selectedLobby || myLobbies.length === 0) {
+      return;
+    }
+
+    const lobby = normalizeLobby(myLobbies[0]);
+    setSelectedLobby(lobby);
+    setJoinLobbyId(lobby.id);
+    if (!lobby.isPrivate) {
+      setJoinToken("");
+    }
+  }, [myLobbies, selectedLobby]);
 
   useEffect(() => {
     setCreateAiCount((count) => Math.min(count, createMaxPlayers - 1));
@@ -414,6 +473,8 @@ export function LobbiesPage() {
       });
       setSelectedLobby(normalizeLobby(lobby));
       setJoinLobbyId(lobby.id);
+      setJoinToken("");
+      revealSelectedLobby();
       if (lobby.isPrivate) {
         try {
           await createLobbyInvite(lobby.id);
@@ -456,6 +517,7 @@ export function LobbiesPage() {
     }
 
     await refreshSelectedLobby(resolved.lobbyId);
+    revealSelectedLobby();
   };
 
   const onJoinLobby = async () => {
@@ -469,11 +531,16 @@ export function LobbiesPage() {
     setMessage(null);
     setInviteShare(null);
     try {
-      const lobby = resolved.token
+      const shouldUseInviteToken =
+        Boolean(resolved.token) &&
+        (selectedLobby?.id !== resolved.lobbyId || selectedLobby.isPrivate);
+      const lobby = shouldUseInviteToken
         ? await joinLobbyWithToken(resolved.lobbyId, resolved.token)
         : await joinLobby(resolved.lobbyId);
       setSelectedLobby(normalizeLobby(lobby));
       setJoinLobbyId(lobby.id);
+      setJoinToken(lobby.isPrivate ? resolved.token : "");
+      revealSelectedLobby();
       setMessage({ kind: "ok", text: `Joined lobby ${lobby.id}` });
       await refreshMyLobbies();
       await refreshPublicLobbies();
@@ -838,7 +905,9 @@ export function LobbiesPage() {
                               className="button buttonSecondary"
                               onClick={() => {
                                 setJoinLobbyId(lobby.id);
+                                setJoinToken("");
                                 void refreshSelectedLobby(lobby.id);
+                                revealSelectedLobby();
                               }}
                             >
                               Open
@@ -897,7 +966,9 @@ export function LobbiesPage() {
                       className="button buttonSecondary"
                       onClick={() => {
                         setJoinLobbyId(lobby.id);
+                        setJoinToken("");
                         void refreshSelectedLobby(lobby.id);
+                        revealSelectedLobby();
                       }}
                     >
                       Select
@@ -910,7 +981,7 @@ export function LobbiesPage() {
         )}
       </div>
 
-      <div className="card">
+      <div className="card" ref={selectedLobbyCardRef} id="selected-lobby-room">
         <h2>Selected lobby</h2>
         {!selectedLobby && (
           <p className="emptyState">
@@ -926,6 +997,8 @@ export function LobbiesPage() {
               </dd>
               <dt className="muted">Status</dt>
               <dd>{selectedLobby.status}</dd>
+              <dt className="muted">Live updates</dt>
+              <dd>{lobbyWsStatus}</dd>
               <dt className="muted">Host</dt>
               <dd>{selectedLobby.hostId}</dd>
               <dt className="muted">Visibility</dt>
@@ -1047,6 +1120,7 @@ export function LobbiesPage() {
                     const labels = [
                       player.userId === user?.userId ? "you" : null,
                       player.isAdmin ? "admin" : null,
+                      player.isReady ? "ready" : "not ready",
                     ].filter(Boolean);
                     return labels.length > 0 ? ` (${labels.join(", ")})` : "";
                   })()}

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -738,14 +738,22 @@ export function LobbiesPage() {
           onAiCountChange={setCreateAiCount}
           onPersonalityChange={setCreateAiPersonality}
         />
-        <label className="checkboxRow">
-          <input
-            type="checkbox"
-            checked={createIsPrivate}
-            onChange={(e) => setCreateIsPrivate(e.target.checked)}
-          />
-          Private lobby
-        </label>
+        <div className="formGrid">
+          <div>
+            <label className="fieldLabel" htmlFor="create-visibility">
+              Lobby visibility
+            </label>
+            <select
+              id="create-visibility"
+              className="textInput"
+              value={createIsPrivate ? "private" : "public"}
+              onChange={(e) => setCreateIsPrivate(e.target.value === "private")}
+            >
+              <option value="public">Public - joinable by lobby ID</option>
+              <option value="private">Private - invite token required</option>
+            </select>
+          </div>
+        </div>
         <button
           type="button"
           className="button"

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -71,6 +71,34 @@ const resolveLobbyJoinInput = (rawLobbyId: string, rawToken: string) => {
   return { lobbyId, token };
 };
 
+type JoinStrategy =
+  | { kind: "public"; lobbyId: string }
+  | { kind: "private"; lobbyId: string; token: string };
+
+const resolveJoinStrategy = (
+  resolved: ReturnType<typeof resolveLobbyJoinInput>,
+  selectedLobby: LobbyResponse | null,
+): JoinStrategy => {
+  const useInviteToken =
+    Boolean(resolved.token) &&
+    (selectedLobby?.id !== resolved.lobbyId || selectedLobby.isPrivate);
+  return useInviteToken
+    ? { kind: "private", lobbyId: resolved.lobbyId, token: resolved.token }
+    : { kind: "public", lobbyId: resolved.lobbyId };
+};
+
+const formatLobbyPlayerLabels = (
+  player: LobbyResponse["players"][number],
+  viewerId: string | undefined,
+) =>
+  [
+    player.userId === viewerId ? "you" : null,
+    player.isAdmin ? "admin" : null,
+    player.isReady ? "ready" : "not ready",
+  ]
+    .filter(Boolean)
+    .join(", ");
+
 const buildInviteUrl = (lobbyId: string, token: string) => {
   const origin =
     typeof window === "undefined" ? "http://localhost" : window.location.origin;
@@ -195,64 +223,51 @@ export function LobbiesPage() {
     }
   }, [user]);
 
-  const refreshSelectedLobby = useCallback(async (id: string) => {
-    if (!id) {
-      setSelectedLobby(null);
-      return;
+  const commitSelectedLobby = useCallback((lobby: LobbyResponse) => {
+    const normalized = normalizeLobby(lobby);
+    setSelectedLobby(normalized);
+    setJoinLobbyId(normalized.id);
+    if (!normalized.isPrivate) {
+      setJoinToken("");
     }
-    try {
-      const lobby = await fetchLobby(id);
-      setSelectedLobby(normalizeLobby(lobby));
-      setJoinLobbyId(lobby.id);
-      if (!lobby.isPrivate) {
-        setJoinToken("");
+    setMyLobbies((current) => {
+      if (!current.some((candidate) => candidate.id === normalized.id)) {
+        return current;
       }
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 404) {
-        setSelectedLobby(null);
-        setMessage({ kind: "error", text: "Lobby not found." });
-        return;
-      }
-      setMessage({
-        kind: "error",
-        text:
-          error instanceof ApiError
-            ? `Failed to load lobby: ${error.message}`
-            : "Failed to load lobby",
-      });
-    }
+      return current.map((candidate) =>
+        candidate.id === normalized.id ? normalized : candidate,
+      );
+    });
   }, []);
 
-  const applySelectedLobbyUpdate = useCallback(
-    (lobby: LobbyResponse) => {
-      const normalized = normalizeLobby(lobby);
-      setSelectedLobby(normalized);
-      setJoinLobbyId(normalized.id);
-      if (!normalized.isPrivate) {
-        setJoinToken("");
+  const refreshSelectedLobby = useCallback(
+    async (id: string) => {
+      if (!id) {
+        setSelectedLobby(null);
+        return;
       }
-      setMyLobbies((current) => {
-        if (!current.some((candidate) => candidate.id === normalized.id)) {
-          return current;
+      try {
+        commitSelectedLobby(normalizeLobby(await fetchLobby(id)));
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          setSelectedLobby(null);
+          setMessage({ kind: "error", text: "Lobby not found." });
+          return;
         }
-        return current.map((candidate) =>
-          candidate.id === normalized.id ? normalized : candidate,
-        );
-      });
-
-      if (
-        normalized.status === "in_game" &&
-        normalized.gameId &&
-        normalized.players.some((player) => player.userId === user?.userId)
-      ) {
-        navigate(`/games/${normalized.gameId}`);
+        setMessage({
+          kind: "error",
+          text:
+            error instanceof ApiError
+              ? `Failed to load lobby: ${error.message}`
+              : "Failed to load lobby",
+        });
       }
     },
-    [navigate, user?.userId],
+    [commitSelectedLobby],
   );
 
   const { wsStatus: lobbyWsStatus } = useLobbyRealtime(selectedLobby?.id, {
-    onUpdate: ({ lobby }) => applySelectedLobbyUpdate(lobby),
+    onUpdate: ({ lobby }) => commitSelectedLobby(lobby),
   });
 
   useEffect(() => {
@@ -287,35 +302,37 @@ export function LobbiesPage() {
   }, [loading, refreshMyLobbies, user]);
 
   useEffect(() => {
-    if (selectedLobby || myLobbies.length === 0) {
+    if (selectedLobby || myLobbies.length !== 1) {
       return;
     }
 
-    const lobby = normalizeLobby(myLobbies[0]);
-    setSelectedLobby(lobby);
-    setJoinLobbyId(lobby.id);
-    if (!lobby.isPrivate) {
-      setJoinToken("");
-    }
-  }, [myLobbies, selectedLobby]);
+    commitSelectedLobby(normalizeLobby(myLobbies[0]));
+  }, [commitSelectedLobby, myLobbies, selectedLobby]);
 
   useEffect(() => {
-    if (!selectedLobby?.id || selectedLobby.status !== "waiting") {
+    if (
+      !selectedLobby?.id ||
+      selectedLobby.status !== "waiting" ||
+      lobbyWsStatus === "connected"
+    ) {
       return;
     }
 
     const intervalId = window.setInterval(async () => {
       try {
-        applySelectedLobbyUpdate(
-          normalizeLobby(await fetchLobby(selectedLobby.id)),
-        );
+        commitSelectedLobby(normalizeLobby(await fetchLobby(selectedLobby.id)));
       } catch {
         // Keep the current lobby visible if a transient refresh fails.
       }
     }, 2_000);
 
     return () => window.clearInterval(intervalId);
-  }, [applySelectedLobbyUpdate, selectedLobby?.id, selectedLobby?.status]);
+  }, [
+    commitSelectedLobby,
+    lobbyWsStatus,
+    selectedLobby?.id,
+    selectedLobby?.status,
+  ]);
 
   useEffect(() => {
     setCreateAiCount((count) => Math.min(count, createMaxPlayers - 1));
@@ -330,6 +347,16 @@ export function LobbiesPage() {
   }, [selectedLobby, user]);
   const isCurrentSubjectAdmin = Boolean(selectedLobbyMembership?.isAdmin);
   const isAtLobbyLimit = myLobbies.length >= MAX_ACTIVE_LOBBIES_PER_USER;
+
+  useEffect(() => {
+    if (
+      selectedLobby?.status === "in_game" &&
+      selectedLobby.gameId &&
+      selectedLobbyMembership
+    ) {
+      navigate(`/games/${selectedLobby.gameId}`);
+    }
+  }, [navigate, selectedLobby, selectedLobbyMembership]);
 
   const signInHref = useMemo(() => {
     const returnTo = `${location.pathname}${location.search}`;
@@ -489,9 +516,7 @@ export function LobbiesPage() {
           personality: createAiPersonality,
         })),
       });
-      setSelectedLobby(normalizeLobby(lobby));
-      setJoinLobbyId(lobby.id);
-      setJoinToken("");
+      commitSelectedLobby(normalizeLobby(lobby));
       revealSelectedLobby();
       if (lobby.isPrivate) {
         try {
@@ -549,15 +574,15 @@ export function LobbiesPage() {
     setMessage(null);
     setInviteShare(null);
     try {
-      const shouldUseInviteToken =
-        Boolean(resolved.token) &&
-        (selectedLobby?.id !== resolved.lobbyId || selectedLobby.isPrivate);
-      const lobby = shouldUseInviteToken
-        ? await joinLobbyWithToken(resolved.lobbyId, resolved.token)
-        : await joinLobby(resolved.lobbyId);
-      setSelectedLobby(normalizeLobby(lobby));
-      setJoinLobbyId(lobby.id);
-      setJoinToken(lobby.isPrivate ? resolved.token : "");
+      const strategy = resolveJoinStrategy(resolved, selectedLobby);
+      const lobby =
+        strategy.kind === "private"
+          ? await joinLobbyWithToken(strategy.lobbyId, strategy.token)
+          : await joinLobby(strategy.lobbyId);
+      commitSelectedLobby(normalizeLobby(lobby));
+      if (lobby.isPrivate) {
+        setJoinToken(resolved.token);
+      }
       revealSelectedLobby();
       setMessage({ kind: "ok", text: `Joined lobby ${lobby.id}` });
       await refreshMyLobbies();
@@ -1148,12 +1173,11 @@ export function LobbiesPage() {
                 <li key={player.userId}>
                   <code className="inline">{player.userId}</code>
                   {(() => {
-                    const labels = [
-                      player.userId === user?.userId ? "you" : null,
-                      player.isAdmin ? "admin" : null,
-                      player.isReady ? "ready" : "not ready",
-                    ].filter(Boolean);
-                    return labels.length > 0 ? ` (${labels.join(", ")})` : "";
+                    const labels = formatLobbyPlayerLabels(
+                      player,
+                      user?.userId,
+                    );
+                    return labels ? ` (${labels})` : "";
                   })()}
                 </li>
               ))}

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -824,7 +824,12 @@ export function LobbiesPage() {
               id="join-id"
               className="textInput"
               value={joinLobbyId}
-              onChange={(e) => setJoinLobbyId(e.target.value)}
+              onChange={(e) => {
+                const nextValue = e.target.value;
+                const parsed = resolveLobbyJoinInput(nextValue, "");
+                setJoinLobbyId(nextValue);
+                setJoinToken(parsed.token);
+              }}
               placeholder="Paste lobby id or invite link"
             />
           </div>

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -302,14 +302,6 @@ export function LobbiesPage() {
   }, [loading, refreshMyLobbies, user]);
 
   useEffect(() => {
-    if (selectedLobby || myLobbies.length !== 1) {
-      return;
-    }
-
-    commitSelectedLobby(normalizeLobby(myLobbies[0]));
-  }, [commitSelectedLobby, myLobbies, selectedLobby]);
-
-  useEffect(() => {
     if (
       !selectedLobby?.id ||
       selectedLobby.status !== "waiting" ||

--- a/packages/worker/migrations/0009_lobby_invites.sql
+++ b/packages/worker/migrations/0009_lobby_invites.sql
@@ -1,0 +1,9 @@
+-- D1-backed invite claims make lobby invite tokens single-use atomically.
+CREATE TABLE IF NOT EXISTS lobby_invites (
+  token TEXT PRIMARY KEY,
+  lobby_id TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_lobby_invites_lobby_id ON lobby_invites(lobby_id);

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -9,13 +9,13 @@ import {
   applyTimeoutTakeoverAndStep,
   runAiTurnLoop,
 } from "../services/gameAi.js";
+import { publicStateForBroadcast } from "../services/gamePersistence.js";
 import { syncGameRoomTimer } from "../services/gameScheduler.js";
 import {
   buildLobbyResponse,
   type LobbyPlayerRow,
   type LobbyRow,
 } from "../services/lobbyResponses.js";
-import { publicStateForBroadcast } from "../services/gamePersistence.js";
 import { currentTurnActorId } from "../services/turnTimeout.js";
 
 type RoomEnv = {

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -3,6 +3,7 @@ import {
   isAiControlledActor,
   normalizeGameState,
 } from "@oligopoly/shared";
+import { toClientGameState } from "../gameStateView.js";
 import {
   applyAuctionBidWindowExpiry,
   applyAuctionSettleExpiry,
@@ -180,14 +181,19 @@ export class GameRoom extends RealtimeRoom {
     const url = new URL(request.url);
     const gameId = url.searchParams.get("gameId") ?? "";
     const spectator = url.searchParams.get("spectator") === "1";
+    const viewerId = url.searchParams.get("viewerId") ?? "spectator";
     if (gameId) {
       await this.state.storage.put("gameId", gameId);
     }
-    const payload = await this.loadGamePayload(gameId, spectator);
+    const payload = await this.loadGamePayload(gameId, spectator, viewerId);
     return jsonEvent("game.snapshot", { gameId, payload });
   }
 
-  private async loadGamePayload(gameId: string, spectator: boolean) {
+  private async loadGamePayload(
+    gameId: string,
+    spectator: boolean,
+    viewerId: string,
+  ) {
     if (!this.env.DB || !gameId) {
       return { gameId, spectator, connected: true };
     }
@@ -204,8 +210,9 @@ export class GameRoom extends RealtimeRoom {
 
     const raw = JSON.parse(row.state_json) as Record<string, unknown>;
     const gameState = normalizeGameState(raw);
-    const publicState = publicStateForBroadcast(gameState, []);
-    return { ...publicState, gameId };
+    return spectator
+      ? toClientGameState(gameState as never, "spectator", viewerId)
+      : toClientGameState(gameState as never, "player", viewerId);
   }
 
   private async resyncFromDatabase(gameId: string) {

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -15,6 +15,7 @@ import {
   type LobbyPlayerRow,
   type LobbyRow,
 } from "../services/lobbyResponses.js";
+import { publicStateForBroadcast } from "../services/gamePersistence.js";
 import { currentTurnActorId } from "../services/turnTimeout.js";
 
 type RoomEnv = {
@@ -203,8 +204,8 @@ export class GameRoom extends RealtimeRoom {
 
     const raw = JSON.parse(row.state_json) as Record<string, unknown>;
     const gameState = normalizeGameState(raw);
-    const { affinityAssignments: _hidden, ...publicState } = gameState;
-    return { ...publicState, gameId, spectator };
+    const publicState = publicStateForBroadcast(gameState, []);
+    return { ...publicState, gameId };
   }
 
   private async resyncFromDatabase(gameId: string) {

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -31,6 +31,7 @@ function jsonEvent(type: string, payload: Record<string, unknown>) {
 
 abstract class RealtimeRoom {
   protected sessions = new Set<WebSocket>();
+  protected sessionUrls = new Map<WebSocket, URL>();
 
   constructor(
     protected readonly state: DurableObjectState,
@@ -53,8 +54,15 @@ abstract class RealtimeRoom {
     const [client, server] = Object.values(pair);
     server.accept();
     this.sessions.add(server);
-    server.addEventListener("close", () => this.sessions.delete(server));
-    server.addEventListener("error", () => this.sessions.delete(server));
+    this.sessionUrls.set(server, new URL(request.url));
+    server.addEventListener("close", () => {
+      this.sessions.delete(server);
+      this.sessionUrls.delete(server);
+    });
+    server.addEventListener("error", () => {
+      this.sessions.delete(server);
+      this.sessionUrls.delete(server);
+    });
     server.send(await this.snapshotEvent(request));
 
     return new Response(null, { status: 101, webSocket: client });
@@ -70,6 +78,7 @@ abstract class RealtimeRoom {
         session.send(message);
       } catch {
         this.sessions.delete(session);
+        this.sessionUrls.delete(session);
       }
     }
   }
@@ -110,6 +119,44 @@ export class LobbyRoom extends RealtimeRoom {
 }
 
 export class GameRoom extends RealtimeRoom {
+  protected broadcast(message: string) {
+    let event: Record<string, unknown> | null = null;
+    try {
+      event = JSON.parse(message) as Record<string, unknown>;
+    } catch {
+      event = null;
+    }
+
+    if (
+      event &&
+      (event.type === "game.action_applied" ||
+        event.type === "game.schedule" ||
+        event.type === "game.snapshot") &&
+      event.state
+    ) {
+      for (const session of this.sessions) {
+        const url = this.sessionUrls.get(session);
+        const spectator = url?.searchParams.get("spectator") === "1";
+        const viewerId = url?.searchParams.get("viewerId") ?? "spectator";
+        const state = normalizeGameState(
+          event.state as Record<string, unknown>,
+        );
+        const scopedState = spectator
+          ? toClientGameState(state as never, "spectator", viewerId)
+          : toClientGameState(state as never, "player", viewerId);
+        try {
+          session.send(JSON.stringify({ ...event, state: scopedState }));
+        } catch {
+          this.sessions.delete(session);
+          this.sessionUrls.delete(session);
+        }
+      }
+      return;
+    }
+
+    super.broadcast(message);
+  }
+
   protected async handleNotify(body: string): Promise<void> {
     if (await this.state.storage.get<boolean>("aiLoopRunning")) {
       this.broadcast(body);

--- a/packages/worker/src/durable/rooms.ts
+++ b/packages/worker/src/durable/rooms.ts
@@ -10,6 +10,11 @@ import {
   runAiTurnLoop,
 } from "../services/gameAi.js";
 import { syncGameRoomTimer } from "../services/gameScheduler.js";
+import {
+  buildLobbyResponse,
+  type LobbyPlayerRow,
+  type LobbyRow,
+} from "../services/lobbyResponses.js";
 import { currentTurnActorId } from "../services/turnTimeout.js";
 
 type RoomEnv = {
@@ -83,58 +88,22 @@ export class LobbyRoom extends RealtimeRoom {
     }
 
     const lobby = await this.env.DB.prepare(
-      "SELECT id, name, host_id, status, max_players, is_private, optional_rule_ids_json, created_at, ai_slots_json FROM lobbies WHERE id = ?",
+      "SELECT * FROM lobbies WHERE id = ?",
     )
       .bind(lobbyId)
-      .first<{
-        id: string;
-        name: string;
-        host_id: string;
-        status: string;
-        max_players: number;
-        is_private: number;
-        optional_rule_ids_json: string | null;
-        created_at: number;
-        ai_slots_json: string | null;
-      }>();
+      .first<LobbyRow>();
 
     if (!lobby) {
       return { lobbyId, connected: true, missing: true };
     }
 
     const playersResult = await this.env.DB.prepare(
-      "SELECT user_id, is_admin, joined_at FROM lobby_players WHERE lobby_id = ? ORDER BY joined_at ASC",
+      "SELECT * FROM lobby_players WHERE lobby_id = ? ORDER BY joined_at ASC",
     )
       .bind(lobbyId)
-      .all<{ user_id: string; is_admin: number; joined_at: number }>();
+      .all<LobbyPlayerRow>();
 
-    let aiSlots: unknown[] = [];
-    if (lobby.ai_slots_json) {
-      try {
-        aiSlots = JSON.parse(lobby.ai_slots_json) as unknown[];
-      } catch {
-        aiSlots = [];
-      }
-    }
-
-    return {
-      id: lobby.id,
-      name: lobby.name,
-      hostId: lobby.host_id,
-      status: lobby.status,
-      maxPlayers: lobby.max_players,
-      isPrivate: lobby.is_private === 1,
-      optionalRuleIds: lobby.optional_rule_ids_json
-        ? JSON.parse(lobby.optional_rule_ids_json)
-        : [],
-      createdAt: lobby.created_at,
-      aiSlots,
-      players: playersResult.results.map((player) => ({
-        userId: player.user_id,
-        isAdmin: player.is_admin === 1,
-        joinedAt: player.joined_at,
-      })),
-    };
+    return buildLobbyResponse(this.env.DB, lobby, playersResult.results);
   }
 }
 

--- a/packages/worker/src/gameStateView.ts
+++ b/packages/worker/src/gameStateView.ts
@@ -154,7 +154,9 @@ function filterNegotiationThreadsForViewer(
   mode: "spectator" | "player",
 ) {
   if (!threads?.length) return threads;
-  if (mode === "spectator") return threads;
+  if (mode === "spectator") {
+    return threads.filter((thread) => thread.visibility === "open");
+  }
   return threads.filter(
     (thread) =>
       thread.visibility === "open" || thread.partyIds.includes(viewerId),

--- a/packages/worker/src/middleware/authSubject.ts
+++ b/packages/worker/src/middleware/authSubject.ts
@@ -61,7 +61,27 @@ export const authSubjectMiddleware: MiddlewareHandler<{
     }
   }
 
-  // 2. Fall back to legacy x-subject header
+  // 2. Browser WebSocket clients cannot send Authorization headers, so
+  // accept the same bearer token via query string for upgrade requests only.
+  if (c.req.header("Upgrade") === "websocket") {
+    const token = toValue(new URL(c.req.url).searchParams.get("access_token"));
+    if (token) {
+      const session = await db
+        .prepare(
+          "SELECT s.user_id, u.role FROM auth_sessions s JOIN users u ON s.user_id = u.id WHERE s.token = ? AND s.expires_at > ?",
+        )
+        .bind(token, Date.now())
+        .first<{ user_id: string; role: string }>();
+      if (session) {
+        c.set("userId", session.user_id);
+        c.set("userRole", session.role);
+        await next();
+        return;
+      }
+    }
+  }
+
+  // 3. Fall back to legacy x-subject header
   const subject = toValue(c.req.header("x-subject"));
   if (subject) {
     const row = await db

--- a/packages/worker/src/realtime/upgrade.ts
+++ b/packages/worker/src/realtime/upgrade.ts
@@ -43,6 +43,7 @@ export function upgradeWebSocket(
   const stub = room.get(objectId);
   const url = new URL(c.req.url);
   url.searchParams.set(roomParam, roomParamValue);
+  url.searchParams.delete("access_token");
   if (extraSearchParams) {
     for (const [key, value] of Object.entries(extraSearchParams)) {
       url.searchParams.set(key, value);

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -58,25 +58,6 @@ async function loadGameAccessRow(
     .first<GameAccessRow>();
 }
 
-async function resolveWebSocketSubject(
-  db: D1Database,
-  requestUrl: string,
-  headerSubject: string | undefined,
-): Promise<string | null> {
-  if (headerSubject) return headerSubject;
-
-  const token = new URL(requestUrl).searchParams.get("access_token")?.trim();
-  if (!token) return null;
-
-  const session = await db
-    .prepare(
-      "SELECT user_id FROM auth_sessions WHERE token = ? AND expires_at > ?",
-    )
-    .bind(token, Date.now())
-    .first<{ user_id: string }>();
-  return session?.user_id ?? null;
-}
-
 function gameSpectatorModeEnabled(row: GameAccessRow): boolean {
   if (!row.state_json) return false;
   const state = JSON.parse(row.state_json) as PersistedGameState;
@@ -490,7 +471,7 @@ gameRoutes.get("/:id/ws", async (c) => {
     return c.json({ error: GameErrorKeys.DB_NOT_CONFIGURED }, 500);
   }
 
-  const subject = await resolveWebSocketSubject(db, c.req.url, c.get("userId"));
+  const subject = c.get("userId");
   if (!subject) {
     return c.json({ error: GameErrorKeys.AUTH_REQUIRED }, 401);
   }

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -394,7 +394,6 @@ gameRoutes.post("/:id/action", async (c) => {
     const logEntries = await persistGameActionResult(db, id, result, {
       gameRoom: c.env?.GAME_ROOM,
       actorId: subject,
-      action: actionBody,
       kv: c.env?.KV,
     });
 

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -396,6 +396,9 @@ gameRoutes.post("/:id/ai/step", async (c) => {
   if (!isLocalDevRequest(c.req.url)) {
     return c.json({ error: GameErrorKeys.FORBIDDEN }, 403);
   }
+  if (!c.get("userId")) {
+    return c.json({ error: GameErrorKeys.AUTH_REQUIRED }, 401);
+  }
 
   const db = c.env?.DB;
   if (!db) {

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -410,13 +410,14 @@ gameRoutes.post("/:id/action", async (c) => {
   try {
     const result = applyAction(gameState, subject, engineInput);
 
-    await persistGameActionResult(db, id, result, {
+    const logEntries = await persistGameActionResult(db, id, result, {
       gameRoom: c.env?.GAME_ROOM,
       actorId: subject,
+      action: actionBody,
       kv: c.env?.KV,
     });
 
-    return c.json(toActionResponse(result, subject));
+    return c.json(toActionResponse(result, subject, { logEntries }));
   } catch (err) {
     if (typeof err === "string") {
       return c.json({ error: err }, 400);

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -37,6 +37,11 @@ type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 export const gameRoutes = new Hono<AppEnv>();
 
+const isLocalDevRequest = (url: string) => {
+  const hostname = new URL(url).hostname;
+  return hostname === "localhost" || hostname === "127.0.0.1";
+};
+
 // ---------------------------------------------------------------------------
 // GET /api/games
 // Returns a paginated list of games. Supports ?status=active|completed.
@@ -388,6 +393,10 @@ gameRoutes.post("/:id/action", async (c) => {
 // ---------------------------------------------------------------------------
 gameRoutes.post("/:id/ai/step", async (c) => {
   const id = c.req.param("id");
+  if (!isLocalDevRequest(c.req.url)) {
+    return c.json({ error: GameErrorKeys.FORBIDDEN }, 403);
+  }
+
   const db = c.env?.DB;
   if (!db) {
     return c.json({ error: GameErrorKeys.DB_NOT_CONFIGURED }, 500);

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -449,7 +449,7 @@ gameRoutes.post("/:id/ai/step", async (c) => {
 
 gameRoutes.get("/:id/ws", async (c) => {
   const id = c.req.param("id") ?? "";
-  const upgradeOptions = {
+  const upgradeOptions: Parameters<typeof upgradeWebSocket>[1] = {
     room: c.env?.GAME_ROOM,
     roomId: id,
     roomParam: "gameId",
@@ -474,6 +474,8 @@ gameRoutes.get("/:id/ws", async (c) => {
   if (!subject) {
     return c.json({ error: GameErrorKeys.AUTH_REQUIRED }, 401);
   }
+
+  upgradeOptions.extraSearchParams = { viewerId: subject };
 
   const row = await loadGameAccessRow(db, id);
   if (!row) {

--- a/packages/worker/src/routes/games.ts
+++ b/packages/worker/src/routes/games.ts
@@ -42,6 +42,47 @@ const isLocalDevRequest = (url: string) => {
   return hostname === "localhost" || hostname === "127.0.0.1";
 };
 
+type GameAccessRow = {
+  id: string;
+  player_ids_json: string;
+  state_json: string | null;
+};
+
+async function loadGameAccessRow(
+  db: D1Database,
+  gameId: string,
+): Promise<GameAccessRow | null> {
+  return db
+    .prepare("SELECT id, player_ids_json, state_json FROM games WHERE id = ?")
+    .bind(gameId)
+    .first<GameAccessRow>();
+}
+
+async function resolveWebSocketSubject(
+  db: D1Database,
+  requestUrl: string,
+  headerSubject: string | undefined,
+): Promise<string | null> {
+  if (headerSubject) return headerSubject;
+
+  const token = new URL(requestUrl).searchParams.get("access_token")?.trim();
+  if (!token) return null;
+
+  const session = await db
+    .prepare(
+      "SELECT user_id FROM auth_sessions WHERE token = ? AND expires_at > ?",
+    )
+    .bind(token, Date.now())
+    .first<{ user_id: string }>();
+  return session?.user_id ?? null;
+}
+
+function gameSpectatorModeEnabled(row: GameAccessRow): boolean {
+  if (!row.state_json) return false;
+  const state = JSON.parse(row.state_json) as PersistedGameState;
+  return state.settings?.spectatorMode === "enabled";
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/games
 // Returns a paginated list of games. Supports ?status=active|completed.
@@ -425,9 +466,9 @@ gameRoutes.post("/:id/ai/step", async (c) => {
   );
 });
 
-gameRoutes.get("/:id/ws", (c) => {
+gameRoutes.get("/:id/ws", async (c) => {
   const id = c.req.param("id") ?? "";
-  return upgradeWebSocket(c, {
+  const upgradeOptions = {
     room: c.env?.GAME_ROOM,
     roomId: id,
     roomParam: "gameId",
@@ -437,12 +478,38 @@ gameRoutes.get("/:id/ws", (c) => {
       gameId: id,
       payload: { gameId: id, spectator: false, connected: true },
     },
-  });
+  };
+
+  if (c.req.header("Upgrade") !== "websocket") {
+    return upgradeWebSocket(c, upgradeOptions);
+  }
+
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: GameErrorKeys.DB_NOT_CONFIGURED }, 500);
+  }
+
+  const subject = await resolveWebSocketSubject(db, c.req.url, c.get("userId"));
+  if (!subject) {
+    return c.json({ error: GameErrorKeys.AUTH_REQUIRED }, 401);
+  }
+
+  const row = await loadGameAccessRow(db, id);
+  if (!row) {
+    return c.json({ error: GameErrorKeys.NOT_FOUND }, 404);
+  }
+
+  const playerIds = JSON.parse(row.player_ids_json) as string[];
+  if (!playerIds.includes(subject)) {
+    return c.json({ error: GameErrorKeys.NOT_PLAYER }, 403);
+  }
+
+  return upgradeWebSocket(c, upgradeOptions);
 });
 
-gameRoutes.get("/:id/spectate", (c) => {
+gameRoutes.get("/:id/spectate", async (c) => {
   const id = c.req.param("id") ?? "";
-  return upgradeWebSocket(c, {
+  const upgradeOptions = {
     room: c.env?.GAME_ROOM,
     roomId: id,
     roomParam: "gameId",
@@ -453,5 +520,25 @@ gameRoutes.get("/:id/spectate", (c) => {
       gameId: id,
       payload: { gameId: id, spectator: true, connected: true },
     },
-  });
+  };
+
+  if (c.req.header("Upgrade") !== "websocket") {
+    return upgradeWebSocket(c, upgradeOptions);
+  }
+
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: GameErrorKeys.DB_NOT_CONFIGURED }, 500);
+  }
+
+  const row = await loadGameAccessRow(db, id);
+  if (!row) {
+    return c.json({ error: GameErrorKeys.NOT_FOUND }, 404);
+  }
+
+  if (!gameSpectatorModeEnabled(row)) {
+    return c.json({ error: GameErrorKeys.FORBIDDEN }, 403);
+  }
+
+  return upgradeWebSocket(c, upgradeOptions);
 });

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -119,6 +119,58 @@ const publishLobbyUpdate = async (
   });
 };
 
+const INVITE_TTL_SECONDS = 24 * 60 * 60;
+
+async function storeInviteToken(
+  db: D1Database,
+  kv: KVNamespace,
+  token: string,
+  lobbyId: string,
+  now: number,
+) {
+  await kv.put(`lobby:invite:${token}`, lobbyId, {
+    expirationTtl: INVITE_TTL_SECONDS,
+  });
+
+  try {
+    await db
+      .prepare(
+        "INSERT INTO lobby_invites (token, lobby_id, expires_at, created_at) VALUES (?, ?, ?, ?)",
+      )
+      .bind(token, lobbyId, now + INVITE_TTL_SECONDS * 1000, now)
+      .run();
+  } catch {
+    // Local databases created before this migration can keep using KV invites.
+  }
+}
+
+async function consumeInviteToken(
+  db: D1Database,
+  kv: KVNamespace,
+  token: string,
+  lobbyId: string,
+  now: number,
+): Promise<boolean> {
+  try {
+    const claimed = await db
+      .prepare(
+        "DELETE FROM lobby_invites WHERE token = ? AND lobby_id = ? AND expires_at > ? RETURNING lobby_id",
+      )
+      .bind(token, lobbyId, now)
+      .first<{ lobby_id: string }>();
+    if (claimed?.lobby_id === lobbyId) {
+      await kv.delete(`lobby:invite:${token}`).catch(() => {});
+      return true;
+    }
+    return false;
+  } catch {
+    const tokenLobbyId = await kv.get(`lobby:invite:${token}`);
+    if (tokenLobbyId !== lobbyId) return false;
+    await kv.delete(`lobby:invite:${token}`).catch(() => {});
+    return true;
+  }
+}
+
 const isWaitingLobbyStatus = (status: string) => status === "waiting";
 
 const compareLobbyPlayers = (a: LobbyPlayerRow, b: LobbyPlayerRow) =>
@@ -576,8 +628,8 @@ lobbyRoutes.post("/:id/join/:token", async (c) => {
     return c.json({ error: LobbyErrorKeys.INVALID_TOKEN }, 403);
   }
 
-  const tokenLobbyId = await kv.get(`lobby:invite:${token}`);
-  if (tokenLobbyId !== id) {
+  const now = Date.now();
+  if (!(await consumeInviteToken(db, kv, token, id, now))) {
     return c.json({ error: LobbyErrorKeys.INVALID_TOKEN }, 403);
   }
 
@@ -620,7 +672,6 @@ lobbyRoutes.post("/:id/join/:token", async (c) => {
     return c.json({ error: LobbyErrorKeys.FULL }, 409);
   }
 
-  const now = Date.now();
   await db
     .prepare(
       "INSERT INTO lobby_players (lobby_id, user_id, is_admin, joined_at) VALUES (?, ?, 0, ?)",
@@ -634,7 +685,6 @@ lobbyRoutes.post("/:id/join/:token", async (c) => {
   ];
 
   const tokenJoinResponse = await buildLobbyResponse(db, lobby, updatedPlayers);
-  await kv.delete(`lobby:invite:${token}`);
   await publishLobbyUpdate(c.env, id, tokenJoinResponse);
   return c.json(tokenJoinResponse);
 });
@@ -673,10 +723,9 @@ lobbyRoutes.post("/:id/invite", async (c) => {
   }
 
   const token = generateId();
-  const ttlSeconds = 24 * 60 * 60;
-  await kv.put(`lobby:invite:${token}`, id, { expirationTtl: ttlSeconds });
+  await storeInviteToken(db, kv, token, id, Date.now());
 
-  return c.json({ token, expiresInSeconds: ttlSeconds });
+  return c.json({ token, expiresInSeconds: INVITE_TTL_SECONDS });
 });
 
 // DELETE /:id/leave — Leave a waiting lobby, deleting it if it becomes empty

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -628,11 +628,6 @@ lobbyRoutes.post("/:id/join/:token", async (c) => {
     return c.json({ error: LobbyErrorKeys.INVALID_TOKEN }, 403);
   }
 
-  const now = Date.now();
-  if (!(await consumeInviteToken(db, kv, token, id, now))) {
-    return c.json({ error: LobbyErrorKeys.INVALID_TOKEN }, 403);
-  }
-
   const lobby = await db
     .prepare("SELECT * FROM lobbies WHERE id = ?")
     .bind(id)
@@ -670,6 +665,11 @@ lobbyRoutes.post("/:id/join/:token", async (c) => {
     lobby.max_players
   ) {
     return c.json({ error: LobbyErrorKeys.FULL }, 409);
+  }
+
+  const now = Date.now();
+  if (!(await consumeInviteToken(db, kv, token, id, now))) {
+    return c.json({ error: LobbyErrorKeys.INVALID_TOKEN }, 403);
   }
 
   await db
@@ -1343,9 +1343,9 @@ lobbyRoutes.post("/:id/start", async (c) => {
 });
 
 // GET /:id/ws — WebSocket upgrade for live lobby events.
-lobbyRoutes.get("/:id/ws", (c) => {
+lobbyRoutes.get("/:id/ws", async (c) => {
   const id = c.req.param("id") ?? "";
-  return upgradeWebSocket(c, {
+  const upgradeOptions = {
     room: c.env?.LOBBY_ROOM,
     roomId: id,
     roomParam: "lobbyId",
@@ -1355,5 +1355,35 @@ lobbyRoutes.get("/:id/ws", (c) => {
       lobbyId: id,
       payload: { lobbyId: id, connected: true },
     },
-  });
+  };
+
+  if (c.req.header("Upgrade") !== "websocket") {
+    return upgradeWebSocket(c, upgradeOptions);
+  }
+
+  const db = c.env?.DB;
+  if (!db) {
+    return c.json({ error: "Database not configured" }, 500);
+  }
+
+  const lobby = await getLobbyById(db, id);
+  if (!lobby) {
+    return c.json({ error: LobbyErrorKeys.NOT_FOUND }, 404);
+  }
+
+  if (lobby.is_private !== 1) {
+    return upgradeWebSocket(c, upgradeOptions);
+  }
+
+  const subject = getSubject(c);
+  if (!subject) {
+    return c.json({ error: LobbyErrorKeys.AUTH_REQUIRED }, 401);
+  }
+
+  const players = await listLobbyPlayers(db, id);
+  if (!players.some((player) => player.user_id === subject)) {
+    return c.json({ error: LobbyErrorKeys.NOT_IN_LOBBY }, 403);
+  }
+
+  return upgradeWebSocket(c, upgradeOptions);
 });

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -448,7 +448,11 @@ lobbyRoutes.get("/", async (c) => {
   const nextCursor = hasMore ? `${lastItem.created_at}:${lastItem.id}` : null;
 
   return c.json({
-    lobbies: await Promise.all(items.map((row) => buildLobbyResponse(db, row))),
+    lobbies: await Promise.all(
+      items.map(async (row) =>
+        buildLobbyResponse(db, row, await listLobbyPlayers(db, row.id)),
+      ),
+    ),
     nextCursor,
   });
 });

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -128,20 +128,16 @@ async function storeInviteToken(
   lobbyId: string,
   now: number,
 ) {
+  await db
+    .prepare(
+      "INSERT INTO lobby_invites (token, lobby_id, expires_at, created_at) VALUES (?, ?, ?, ?)",
+    )
+    .bind(token, lobbyId, now + INVITE_TTL_SECONDS * 1000, now)
+    .run();
+
   await kv.put(`lobby:invite:${token}`, lobbyId, {
     expirationTtl: INVITE_TTL_SECONDS,
   });
-
-  try {
-    await db
-      .prepare(
-        "INSERT INTO lobby_invites (token, lobby_id, expires_at, created_at) VALUES (?, ?, ?, ?)",
-      )
-      .bind(token, lobbyId, now + INVITE_TTL_SECONDS * 1000, now)
-      .run();
-  } catch {
-    // Local databases created before this migration can keep using KV invites.
-  }
 }
 
 async function consumeInviteToken(
@@ -151,24 +147,17 @@ async function consumeInviteToken(
   lobbyId: string,
   now: number,
 ): Promise<boolean> {
-  try {
-    const claimed = await db
-      .prepare(
-        "DELETE FROM lobby_invites WHERE token = ? AND lobby_id = ? AND expires_at > ? RETURNING lobby_id",
-      )
-      .bind(token, lobbyId, now)
-      .first<{ lobby_id: string }>();
-    if (claimed?.lobby_id === lobbyId) {
-      await kv.delete(`lobby:invite:${token}`).catch(() => {});
-      return true;
-    }
+  const claimed = await db
+    .prepare(
+      "DELETE FROM lobby_invites WHERE token = ? AND lobby_id = ? AND expires_at > ? RETURNING lobby_id",
+    )
+    .bind(token, lobbyId, now)
+    .first<{ lobby_id: string }>();
+  if (claimed?.lobby_id !== lobbyId) {
     return false;
-  } catch {
-    const tokenLobbyId = await kv.get(`lobby:invite:${token}`);
-    if (tokenLobbyId !== lobbyId) return false;
-    await kv.delete(`lobby:invite:${token}`).catch(() => {});
-    return true;
   }
+  await kv.delete(`lobby:invite:${token}`).catch(() => {});
+  return true;
 }
 
 const isWaitingLobbyStatus = (status: string) => status === "waiting";

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -181,6 +181,29 @@ const listLobbyPlayers = async (db: D1Database, lobbyId: string) => {
   return playersResult.results;
 };
 
+const listLobbyPlayersForLobbies = async (
+  db: D1Database,
+  lobbyIds: string[],
+): Promise<Map<string, LobbyPlayerRow[]>> => {
+  const grouped = new Map<string, LobbyPlayerRow[]>();
+  if (lobbyIds.length === 0) return grouped;
+
+  const placeholders = lobbyIds.map(() => "?").join(", ");
+  const result = await db
+    .prepare(
+      `SELECT * FROM lobby_players WHERE lobby_id IN (${placeholders}) ORDER BY joined_at ASC`,
+    )
+    .bind(...lobbyIds)
+    .all<LobbyPlayerRow>();
+
+  for (const player of result.results) {
+    const players = grouped.get(player.lobby_id) ?? [];
+    players.push(player);
+    grouped.set(player.lobby_id, players);
+  }
+  return grouped;
+};
+
 const listUserLobbyMemberships = async (db: D1Database, userId: string) => {
   const membershipsResult = await db
     .prepare("SELECT * FROM lobby_players WHERE user_id = ?")
@@ -488,10 +511,15 @@ lobbyRoutes.get("/", async (c) => {
   const lastItem = items[items.length - 1];
   const nextCursor = hasMore ? `${lastItem.created_at}:${lastItem.id}` : null;
 
+  const playersByLobbyId = await listLobbyPlayersForLobbies(
+    db,
+    items.map((row) => row.id),
+  );
+
   return c.json({
     lobbies: await Promise.all(
-      items.map(async (row) =>
-        buildLobbyResponse(db, row, await listLobbyPlayers(db, row.id)),
+      items.map((row) =>
+        buildLobbyResponse(db, row, playersByLobbyId.get(row.id) ?? []),
       ),
     ),
     nextCursor,

--- a/packages/worker/src/routes/lobbies.ts
+++ b/packages/worker/src/routes/lobbies.ts
@@ -634,6 +634,7 @@ lobbyRoutes.post("/:id/join/:token", async (c) => {
   ];
 
   const tokenJoinResponse = await buildLobbyResponse(db, lobby, updatedPlayers);
+  await kv.delete(`lobby:invite:${token}`);
   await publishLobbyUpdate(c.env, id, tokenJoinResponse);
   return c.json(tokenJoinResponse);
 });
@@ -672,7 +673,7 @@ lobbyRoutes.post("/:id/invite", async (c) => {
   }
 
   const token = generateId();
-  const ttlSeconds = 3600;
+  const ttlSeconds = 24 * 60 * 60;
   await kv.put(`lobby:invite:${token}`, id, { expirationTtl: ttlSeconds });
 
   return c.json({ token, expiresInSeconds: ttlSeconds });

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -21,9 +21,14 @@ type PersistOptions = {
 
 type BroadcastGameState = Omit<
   ApplyActionResult["state"],
-  "affinityAssignments" | "pendingAuction"
+  | "affinityAssignments"
+  | "pendingAuction"
+  | "pendingInsiderPeek"
+  | "handshakeAgreements"
+  | "negotiationThreads"
 > & {
   pendingAuction?: ReturnType<typeof redactPendingAuctionForBroadcast>;
+  negotiationThreads?: ApplyActionResult["state"]["negotiationThreads"];
 };
 
 export function logEntriesForBroadcast(
@@ -66,13 +71,26 @@ export function publicStateForBroadcast(
   state: ApplyActionResult["state"],
   logEntries: ApplyActionResult["logEntries"] = [],
 ): BroadcastGameState {
-  const { affinityAssignments: _affinity, pendingAuction, ...rest } = state;
-  const publicState = pendingAuction
-    ? {
-        ...rest,
-        pendingAuction: redactPendingAuctionForBroadcast(pendingAuction),
-      }
-    : rest;
+  const {
+    affinityAssignments: _affinity,
+    pendingAuction,
+    pendingInsiderPeek: _peek,
+    handshakeAgreements: _handshakes,
+    negotiationThreads,
+    ...rest
+  } = state;
+  const openNegotiationThreads = negotiationThreads?.filter(
+    (thread) => thread.visibility === "open",
+  );
+  const publicState = {
+    ...rest,
+    ...(pendingAuction
+      ? { pendingAuction: redactPendingAuctionForBroadcast(pendingAuction) }
+      : {}),
+    ...(openNegotiationThreads?.length
+      ? { negotiationThreads: openNegotiationThreads }
+      : {}),
+  };
 
   const hiddenTransfer = darkPoolTransferPayload(logEntries);
   if (!hiddenTransfer) {
@@ -195,7 +213,7 @@ export async function persistGameActionResult(
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
     action: options.aiMeta?.action,
-    logEntries: [],
+    logEntries: logEntriesForBroadcast(result.logEntries),
     state: publicState,
   });
 }
@@ -208,14 +226,14 @@ export function toActionResponse(
   if (!subject) {
     return {
       ...publicStateForBroadcast(result.state, result.logEntries),
-      logEntries: [],
+      logEntries: logEntriesForBroadcast(result.logEntries),
       ...extra,
     };
   }
 
   return {
     ...toClientGameState(result.state as PersistedGameState, "player", subject),
-    logEntries: [],
+    logEntries: result.logEntries,
     ...extra,
   };
 }

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -15,7 +15,6 @@ import { processGameCompletion } from "./gameCompletion.js";
 type PersistOptions = {
   gameRoom?: DurableObjectNamespace;
   actorId?: string;
-  action?: GameAction;
   kv?: KVNamespace;
   aiMeta?: {
     aiPlayerId: string;
@@ -234,7 +233,6 @@ export async function persistGameActionResult(
     sentAt: now,
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
-    action: options.action ?? options.aiMeta?.action,
     logEntries: broadcastLogEntries,
     state: publicState,
   });

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -222,7 +222,6 @@ export async function persistGameActionResult(
     await processGameCompletion(db, options.kv, gameId, result.state, now);
   }
 
-  const publicState = publicStateForBroadcast(result.state, result.logEntries);
   const broadcastLogEntries = darkPoolTransferPayload(result.logEntries)
     ? []
     : logRows
@@ -234,7 +233,7 @@ export async function persistGameActionResult(
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
     logEntries: broadcastLogEntries,
-    state: publicState,
+    state: result.state,
   });
 
   return logRows.map(({ apiEntry }) => apiEntry);

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -195,7 +195,7 @@ export async function persistGameActionResult(
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
     action: options.aiMeta?.action,
-    logEntries: logEntriesForBroadcast(result.logEntries),
+    logEntries: [],
     state: publicState,
   });
 }
@@ -208,14 +208,14 @@ export function toActionResponse(
   if (!subject) {
     return {
       ...publicStateForBroadcast(result.state, result.logEntries),
-      logEntries: logEntriesForBroadcast(result.logEntries),
+      logEntries: [],
       ...extra,
     };
   }
 
   return {
     ...toClientGameState(result.state as PersistedGameState, "player", subject),
-    logEntries: result.logEntries,
+    logEntries: [],
     ...extra,
   };
 }

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -71,44 +71,33 @@ function darkPoolTransferPayload(
     : null;
 }
 
-export function publicStateForBroadcast(
-  state: ApplyActionResult["state"],
-  logEntries: ApplyActionResult["logEntries"] = [],
-): BroadcastGameState {
-  const {
-    affinityAssignments: _affinity,
-    pendingAuction,
-    pendingInsiderPeek: _peek,
-    handshakeAgreements: _handshakes,
-    negotiationThreads,
-    ...rest
-  } = state;
-  const openNegotiationThreads = negotiationThreads?.filter(
-    (thread) => thread.visibility === "open",
-  );
-  const publicState = {
-    ...rest,
-    ...(pendingAuction
-      ? { pendingAuction: redactPendingAuctionForBroadcast(pendingAuction) }
-      : {}),
-    ...(openNegotiationThreads?.length
-      ? { negotiationThreads: openNegotiationThreads }
-      : {}),
-  };
-
+function applyDarkPoolTransferRedaction<
+  TState extends {
+    players: Array<{
+      playerId: string;
+      ownedTilePositions: Array<number | string>;
+      mortgagedTilePositions: Array<number | string>;
+    }>;
+    tiles: Array<{
+      position: number | string;
+      ownerId?: string | null;
+      mortgaged?: boolean;
+    }>;
+  },
+>(state: TState, logEntries: ApplyActionResult["logEntries"]): TState {
   const hiddenTransfer = darkPoolTransferPayload(logEntries);
   if (!hiddenTransfer) {
-    return publicState;
+    return state;
   }
 
-  const transferredTile = publicState.tiles.find(
+  const transferredTile = state.tiles.find(
     (tile) => String(tile.position) === String(hiddenTransfer.tilePosition),
   );
   const transferredTileWasMortgaged = transferredTile?.mortgaged === true;
 
   return {
-    ...publicState,
-    players: publicState.players.map((player) => {
+    ...state,
+    players: state.players.map((player) => {
       if (player.playerId === hiddenTransfer.fromPlayerId) {
         return {
           ...player,
@@ -141,12 +130,40 @@ export function publicStateForBroadcast(
       }
       return player;
     }),
-    tiles: publicState.tiles.map((tile) =>
+    tiles: state.tiles.map((tile) =>
       String(tile.position) === String(hiddenTransfer.tilePosition)
         ? { ...tile, ownerId: hiddenTransfer.fromPlayerId }
         : tile,
     ),
   };
+}
+
+export function publicStateForBroadcast(
+  state: ApplyActionResult["state"],
+  logEntries: ApplyActionResult["logEntries"] = [],
+): BroadcastGameState {
+  const {
+    affinityAssignments: _affinity,
+    pendingAuction,
+    pendingInsiderPeek: _peek,
+    handshakeAgreements: _handshakes,
+    negotiationThreads,
+    ...rest
+  } = state;
+  const openNegotiationThreads = negotiationThreads?.filter(
+    (thread) => thread.visibility === "open",
+  );
+  const publicState = {
+    ...rest,
+    ...(pendingAuction
+      ? { pendingAuction: redactPendingAuctionForBroadcast(pendingAuction) }
+      : {}),
+    ...(openNegotiationThreads?.length
+      ? { negotiationThreads: openNegotiationThreads }
+      : {}),
+  };
+
+  return applyDarkPoolTransferRedaction(publicState, logEntries);
 }
 
 export async function persistGameActionResult(
@@ -224,7 +241,7 @@ export async function persistGameActionResult(
 
   const hiddenTransfer = darkPoolTransferPayload(result.logEntries);
   const broadcastState = hiddenTransfer
-    ? publicStateForBroadcast(result.state, result.logEntries)
+    ? applyDarkPoolTransferRedaction(result.state, result.logEntries)
     : result.state;
   const broadcastLogEntries = hiddenTransfer
     ? []

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -222,7 +222,11 @@ export async function persistGameActionResult(
     await processGameCompletion(db, options.kv, gameId, result.state, now);
   }
 
-  const broadcastLogEntries = darkPoolTransferPayload(result.logEntries)
+  const hiddenTransfer = darkPoolTransferPayload(result.logEntries);
+  const broadcastState = hiddenTransfer
+    ? publicStateForBroadcast(result.state, result.logEntries)
+    : result.state;
+  const broadcastLogEntries = hiddenTransfer
     ? []
     : logRows
         .filter(({ entry }) => entry.broadcast !== false)
@@ -233,7 +237,7 @@ export async function persistGameActionResult(
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
     logEntries: broadcastLogEntries,
-    state: result.state,
+    state: broadcastState,
   });
 
   return logRows.map(({ apiEntry }) => apiEntry);

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -213,7 +213,7 @@ export async function persistGameActionResult(
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
     action: options.aiMeta?.action,
-    logEntries: logEntriesForBroadcast(result.logEntries),
+    logEntries: [],
     state: publicState,
   });
 }
@@ -226,14 +226,14 @@ export function toActionResponse(
   if (!subject) {
     return {
       ...publicStateForBroadcast(result.state, result.logEntries),
-      logEntries: logEntriesForBroadcast(result.logEntries),
+      logEntries: [],
       ...extra,
     };
   }
 
   return {
     ...toClientGameState(result.state as PersistedGameState, "player", subject),
-    logEntries: result.logEntries,
+    logEntries: [],
     ...extra,
   };
 }

--- a/packages/worker/src/services/gamePersistence.ts
+++ b/packages/worker/src/services/gamePersistence.ts
@@ -1,5 +1,9 @@
 import type { ApplyActionResult } from "@oligopoly/shared";
-import type { AiPersonality, GameAction } from "@oligopoly/validation";
+import type {
+  AiPersonality,
+  GameAction,
+  GameLogEntry,
+} from "@oligopoly/validation";
 import {
   type PersistedGameState,
   redactPendingAuctionForBroadcast,
@@ -11,6 +15,7 @@ import { processGameCompletion } from "./gameCompletion.js";
 type PersistOptions = {
   gameRoom?: DurableObjectNamespace;
   actorId?: string;
+  action?: GameAction;
   kv?: KVNamespace;
   aiMeta?: {
     aiPlayerId: string;
@@ -150,9 +155,21 @@ export async function persistGameActionResult(
   gameId: string,
   result: ApplyActionResult,
   options: PersistOptions = {},
-): Promise<void> {
+): Promise<GameLogEntry[]> {
   const now = Date.now();
   const stateJson = JSON.stringify(result.state);
+  const logRows = result.logEntries.map((entry) => ({
+    entry,
+    apiEntry: {
+      id: crypto.randomUUID(),
+      gameId,
+      round: result.state.round,
+      playerId: entry.playerId ?? null,
+      actionType: entry.actionType,
+      payload: entry.payload ?? null,
+      createdAt: now,
+    } satisfies GameLogEntry,
+  }));
 
   const statements = [
     db
@@ -182,20 +199,20 @@ export async function persistGameActionResult(
     }
   }
 
-  for (const entry of result.logEntries) {
+  for (const { apiEntry } of logRows) {
     statements.push(
       db
         .prepare(
           "INSERT INTO game_log (id, game_id, round, player_id, action_type, payload_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(
-          crypto.randomUUID(),
-          gameId,
-          result.state.round,
-          entry.playerId,
-          entry.actionType,
-          entry.payload ? JSON.stringify(entry.payload) : null,
-          now,
+          apiEntry.id,
+          apiEntry.gameId,
+          apiEntry.round,
+          apiEntry.playerId,
+          apiEntry.actionType,
+          apiEntry.payload ? JSON.stringify(apiEntry.payload) : null,
+          apiEntry.createdAt,
         ),
     );
   }
@@ -207,15 +224,22 @@ export async function persistGameActionResult(
   }
 
   const publicState = publicStateForBroadcast(result.state, result.logEntries);
+  const broadcastLogEntries = darkPoolTransferPayload(result.logEntries)
+    ? []
+    : logRows
+        .filter(({ entry }) => entry.broadcast !== false)
+        .map(({ apiEntry }) => apiEntry);
   await broadcastGameEvent(options.gameRoom, gameId, {
     type: "game.action_applied",
     sentAt: now,
     gameId,
     actorId: options.actorId ?? options.aiMeta?.aiPlayerId ?? "system",
-    action: options.aiMeta?.action,
-    logEntries: [],
+    action: options.action ?? options.aiMeta?.action,
+    logEntries: broadcastLogEntries,
     state: publicState,
   });
+
+  return logRows.map(({ apiEntry }) => apiEntry);
 }
 
 export function toActionResponse(

--- a/tests/e2e/solo-ai-gameplay.test.ts
+++ b/tests/e2e/solo-ai-gameplay.test.ts
@@ -65,9 +65,24 @@ describe("e2e solo vs AI gameplay", () => {
     });
     expect(endRes.status).toBe(200);
     const endBody = (await endRes.json()) as Record<string, unknown>;
-    expect(["waiting_for_roll", "waiting_for_market_event"]).toContain(
-      endBody.phase,
-    );
+    expect([
+      "waiting_for_roll",
+      "waiting_for_market_event",
+      "syndicate_coordination",
+    ]).toContain(endBody.phase);
+
+    if (endBody.phase === "syndicate_coordination") {
+      const coordinationRes = await requestWithEnv(
+        `/api/games/${gameId}/action`,
+        {
+          method: "POST",
+          headers: { "x-subject": humanId },
+          body: { type: "end_coordination" },
+          db,
+        },
+      );
+      expect(coordinationRes.status).toBe(200);
+    }
 
     const afterAi = await stepAiUntil(
       db,

--- a/tests/e2e/solo-ai-gameplay.test.ts
+++ b/tests/e2e/solo-ai-gameplay.test.ts
@@ -95,6 +95,7 @@ describe("e2e solo vs AI gameplay", () => {
       "waiting_for_roll",
       "rolling_doubles",
       "waiting_for_market_event",
+      "syndicate_coordination",
     ]).toContain(afterAi.phase);
   });
 });

--- a/tests/helpers/workerD1Stub.ts
+++ b/tests/helpers/workerD1Stub.ts
@@ -14,6 +14,7 @@ export function createWorkerD1Stub(): WorkerD1Stub {
     ],
     lobbies: [],
     lobby_players: [],
+    lobby_invites: [],
     games: [],
     game_log: [],
     user_ranks: [],
@@ -125,6 +126,31 @@ export function createWorkerD1Stub(): WorkerD1Stub {
         });
       }
       return { results: [], success: true };
+    }
+
+    if (trimmed.startsWith("INSERT INTO lobby_invites")) {
+      const [token, lobby_id, expires_at, created_at] = binds as [
+        string,
+        string,
+        number,
+        number,
+      ];
+      tables.lobby_invites.push({ token, lobby_id, expires_at, created_at });
+      return { results: [], success: true };
+    }
+
+    if (trimmed.startsWith("DELETE FROM lobby_invites")) {
+      const [token, lobby_id, now] = binds as [string, string, number];
+      const invite = tables.lobby_invites.find(
+        (row) =>
+          row.token === token &&
+          row.lobby_id === lobby_id &&
+          row.expires_at > now,
+      );
+      tables.lobby_invites = tables.lobby_invites.filter(
+        (row) => row !== invite,
+      );
+      return { results: invite ? [invite] : [], first: invite ?? null };
     }
 
     if (trimmed.startsWith("INSERT INTO games")) {

--- a/tests/helpers/workerD1Stub.ts
+++ b/tests/helpers/workerD1Stub.ts
@@ -267,6 +267,14 @@ export function createWorkerD1Stub(): WorkerD1Stub {
       return { results: row ? [row] : [], first: row };
     }
 
+    if (trimmed.startsWith("SELECT * FROM lobby_players WHERE lobby_id IN")) {
+      const ids = new Set(binds as string[]);
+      const rows = tables.lobby_players.filter((r) =>
+        ids.has(r.lobby_id as string),
+      );
+      return { results: rows };
+    }
+
     if (trimmed.startsWith("SELECT * FROM lobby_players WHERE lobby_id = ?")) {
       const rows = tables.lobby_players.filter((r) => r.lobby_id === binds[0]);
       return { results: rows };

--- a/tests/helpers/workerGameplayHarness.ts
+++ b/tests/helpers/workerGameplayHarness.ts
@@ -195,11 +195,13 @@ export async function stepAiUntil(
   gameId: string,
   predicate: (body: Record<string, unknown>) => boolean,
   maxSteps = 16,
+  subject = "user-1",
 ): Promise<Record<string, unknown>> {
   let lastBody: Record<string, unknown> = {};
   for (let i = 0; i < maxSteps; i++) {
     const res = await requestWithEnv(`/api/games/${gameId}/ai/step`, {
       method: "POST",
+      headers: { "x-subject": subject },
       db,
     });
     if (res.status === 409) {
@@ -270,6 +272,7 @@ export async function ensureActorTurn(
 
     const res = await requestWithEnv(`/api/games/${gameId}/ai/step`, {
       method: "POST",
+      headers: { "x-subject": actorId },
       db,
     });
     if (res.status === 409) {

--- a/tests/helpers/workerGameplayHarness.ts
+++ b/tests/helpers/workerGameplayHarness.ts
@@ -109,6 +109,7 @@ async function createAndStartGame(db: D1Database) {
   const updatedState = JSON.parse(updatedRow.state_json as string) as {
     turnOrder: string[];
     players: Array<{ playerId: string; capital: number }>;
+    freeMarketPool?: number;
   };
 
   return {
@@ -120,6 +121,7 @@ async function createAndStartGame(db: D1Database) {
     capitals: Object.fromEntries(
       updatedState.players.map((player) => [player.playerId, player.capital]),
     ) as Record<string, number>,
+    freeMarketPool: updatedState.freeMarketPool ?? 0,
   };
 }
 

--- a/tests/helpers/workerGameplayHarness.ts
+++ b/tests/helpers/workerGameplayHarness.ts
@@ -163,6 +163,8 @@ export async function createSoloAiGame(db: D1Database) {
   }
   const lobby = (await createRes.json()) as Record<string, unknown>;
 
+  await markLobbyPlayersReady(db, lobby.id as string, ["user-1"]);
+
   const startRes = await requestWithEnv(`/api/lobbies/${lobby.id}/start`, {
     method: "POST",
     headers: { "x-subject": "user-1" },

--- a/tests/integration/game-actions.test.ts
+++ b/tests/integration/game-actions.test.ts
@@ -210,7 +210,8 @@ describe("POST /api/games/:id/action — roll_dice", () => {
 describe("POST /api/games/:id/action — buy_tile / decline_tile", () => {
   it("can buy a tile from position 1 (Digital Content Co., cost 60)", async () => {
     const db = createD1Stub();
-    const { gameId, currentPlayer, capitals } = await createAndStartGame(db);
+    const { gameId, currentPlayer, capitals, freeMarketPool } =
+      await createAndStartGame(db);
 
     // Roll [1, 2] = 3 -> position 3 = Mobile Gaming Inc. (cost 80)
     const rollRes = await requestWithEnv(`/api/games/${gameId}/action`, {
@@ -510,7 +511,8 @@ describe("POST /api/games/:id/action — doubles", () => {
 describe("POST /api/games/:id/action — special tiles", () => {
   it("pays Corporate Tax I when landing on position 4", async () => {
     const db = createD1Stub();
-    const { gameId, currentPlayer, capitals } = await createAndStartGame(db);
+    const { gameId, currentPlayer, capitals, freeMarketPool } =
+      await createAndStartGame(db);
 
     // [1, 3] = 4 -> CORPORATE TAX I (pays 75 to free market pool)
     const res = await requestWithEnv(`/api/games/${gameId}/action`, {
@@ -528,7 +530,7 @@ describe("POST /api/games/:id/action — special tiles", () => {
     }>;
     const player = players.find((p) => p.playerId === currentPlayer)!;
     expect(player.capital).toBe(capitals[currentPlayer] - 75);
-    expect(body.freeMarketPool).toBe(75);
+    expect(body.freeMarketPool).toBe(freeMarketPool + 75);
   });
 });
 

--- a/tests/integration/games.test.ts
+++ b/tests/integration/games.test.ts
@@ -105,6 +105,17 @@ function applyWhere(rows: Row[], query: string, params: unknown[]): Row[] {
     return rows.filter((r) => r.status === params[0]);
   }
 
+  const tokenMatch = query.match(/WHERE\s+(?:s\.)?token\s*=\s*\?/i);
+  if (tokenMatch && params.length > 0) {
+    return rows.filter(
+      (r) =>
+        r.token === params[0] &&
+        (typeof r.expires_at !== "number" ||
+          typeof params[1] !== "number" ||
+          r.expires_at > params[1]),
+    );
+  }
+
   const gameIdMatch = query.match(/WHERE\s+game_id\s*=\s*\?/i);
   if (gameIdMatch && params.length > 0) {
     return rows.filter((r) => r.game_id === params[0]);
@@ -185,6 +196,7 @@ function makeEnv(extraTables: Record<string, Row[]> = {}) {
   return {
     DB: makeDb({
       users: [cloneRow(userA), cloneRow(userB), cloneRow(outsiderUser)],
+      auth_sessions: [],
       games: [cloneRow(activeGame), cloneRow(completedGame)],
       game_log: [cloneRow(logEntry), cloneRow(logEntryCompleted)],
       ...extraTables,
@@ -357,6 +369,25 @@ describe("WebSocket upgrades", () => {
     );
 
     expect(res.status).toBe(401);
+  });
+
+  it("GET /api/games/:id/ws rejects an outsider access_token for upgrades", async () => {
+    const res = await app.request(
+      "/api/games/game-active/ws?access_token=outsider-token",
+      { headers: { Upgrade: "websocket" } },
+      makeEnv({
+        auth_sessions: [
+          {
+            token: "outsider-token",
+            user_id: "outsider",
+            role: "user",
+            expires_at: Date.now() + 60_000,
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(403);
   });
 
   it("GET /api/games/:id/spectate rejects upgrades when spectator mode is disabled", async () => {

--- a/tests/integration/games.test.ts
+++ b/tests/integration/games.test.ts
@@ -413,7 +413,7 @@ describe("POST /api/games/:id/ai/step", () => {
 
     const res = await app.request(
       "/api/games/game-ai/ai/step",
-      { method: "POST" },
+      { method: "POST", headers: { "x-subject": PLAYER_A } },
       env,
     );
 
@@ -443,7 +443,7 @@ describe("POST /api/games/:id/ai/step", () => {
 
     const res = await app.request(
       "/api/games/game-completed/ai/step",
-      { method: "POST" },
+      { method: "POST", headers: { "x-subject": PLAYER_A } },
       env,
     );
 

--- a/tests/integration/games.test.ts
+++ b/tests/integration/games.test.ts
@@ -348,6 +348,26 @@ describe("WebSocket upgrades", () => {
     const res = await app.request("/api/games/game-active/spectate");
     expect(res.status).toBe(426);
   });
+
+  it("GET /api/games/:id/ws requires an authenticated player for upgrades", async () => {
+    const res = await app.request(
+      "/api/games/game-active/ws",
+      { headers: { Upgrade: "websocket" } },
+      makeEnv(),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/games/:id/spectate rejects upgrades when spectator mode is disabled", async () => {
+    const res = await app.request(
+      "/api/games/game-active/spectate",
+      { headers: { Upgrade: "websocket" } },
+      makeEnv(),
+    );
+
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("POST /api/games/:id/ai/step", () => {

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -206,6 +206,9 @@ describe("GET /api/lobbies", () => {
     expect(body.lobbies).toBeInstanceOf(Array);
     expect(body.lobbies.length).toBe(1);
     expect(body.lobbies[0].name).toBe("Public Lobby");
+    expect(body.lobbies[0].players).toEqual([
+      expect.objectContaining({ userId: "user-1", isAdmin: true }),
+    ]);
   });
 });
 

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -697,6 +697,37 @@ describe("GET /api/lobbies/:id/ws", () => {
     const res = await requestWithEnv("/api/lobbies/some-id/ws");
     expect(res.status).toBe(426);
   });
+
+  it("requires private lobby membership for WebSocket upgrades", async () => {
+    const db = createD1Stub();
+    const createRes = await requestWithEnv("/api/lobbies", {
+      method: "POST",
+      headers: { "x-subject": "user-1" },
+      body: {
+        name: "Private Lobby",
+        maxPlayers: 4,
+        isPrivate: true,
+        optionalRuleIds: [],
+      },
+      db,
+    });
+    const lobby = await createRes.json();
+
+    const unauthenticated = await requestWithEnv(
+      `/api/lobbies/${lobby.id}/ws`,
+      {
+        headers: { Upgrade: "websocket" },
+        db,
+      },
+    );
+    expect(unauthenticated.status).toBe(401);
+
+    const outsider = await requestWithEnv(`/api/lobbies/${lobby.id}/ws`, {
+      headers: { Upgrade: "websocket", "x-subject": "user-2" },
+      db,
+    });
+    expect(outsider.status).toBe(403);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/lobbies.test.ts
+++ b/tests/integration/lobbies.test.ts
@@ -17,6 +17,9 @@ const createKvStub = () => {
     put: async (key: string, value: string) => {
       store.set(key, value);
     },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
     _store: store,
   } as unknown as KVNamespace;
 };
@@ -660,6 +663,7 @@ describe("POST /api/lobbies/:id/invite + join/:token", () => {
     expect(inviteRes.status).toBe(200);
     const inviteBody = await inviteRes.json();
     expect(inviteBody.token).toBeDefined();
+    expect(inviteBody.expiresInSeconds).toBe(24 * 60 * 60);
 
     // Join via token
     const joinRes = await requestWithEnv(
@@ -674,6 +678,17 @@ describe("POST /api/lobbies/:id/invite + join/:token", () => {
     expect(joinRes.status).toBe(200);
     const joinBody = await joinRes.json();
     expect(joinBody.players).toHaveLength(2);
+
+    const replayJoinRes = await requestWithEnv(
+      `/api/lobbies/${lobby.id}/join/${inviteBody.token}`,
+      {
+        method: "POST",
+        headers: { "x-subject": "user-3" },
+        db,
+        kv,
+      },
+    );
+    expect(replayJoinRes.status).toBe(403);
   });
 });
 

--- a/tests/integration/middleware.test.ts
+++ b/tests/integration/middleware.test.ts
@@ -9,9 +9,10 @@ const createRequestWithEnv = (
     method?: string;
     headers?: HeadersInit;
     kvGet?: KvGet;
+    db?: D1Database;
   } = {},
 ) => {
-  const { method, headers, kvGet } = options;
+  const { method, headers, kvGet, db } = options;
   return app.request(
     path,
     {
@@ -20,6 +21,7 @@ const createRequestWithEnv = (
     },
     {
       ALLOWED_ORIGINS: "http://localhost:5173",
+      DB: db,
       KV: kvGet ? ({ get: kvGet } as KVNamespace) : undefined,
     },
   );
@@ -66,6 +68,28 @@ describe("rateLimitMiddleware", () => {
 });
 
 describe("banCacheMiddleware", () => {
+  it("resolves websocket access_token before ban checks", async () => {
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => ({ user_id: "user-banned", role: "user" }),
+        }),
+      }),
+    } as unknown as D1Database;
+
+    const res = await createRequestWithEnv(
+      "/api/game-config?access_token=ws-token",
+      {
+        headers: { Upgrade: "websocket" },
+        db,
+        kvGet: async (key) => (key === "ban:user-banned" ? "1" : null),
+      },
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "account_banned" });
+  });
+
   it("returns 403 when ban key is flagged", async () => {
     const res = await createRequestWithEnv("/api/game-config", {
       method: "GET",

--- a/tests/unit/gamePersistence.test.ts
+++ b/tests/unit/gamePersistence.test.ts
@@ -59,6 +59,63 @@ describe("logEntriesForBroadcast", () => {
 });
 
 describe("publicStateForBroadcast", () => {
+  it("strips private game state from broadcast snapshots", () => {
+    const broadcastState = publicStateForBroadcast({
+      players: [],
+      tiles: [],
+      pendingInsiderPeek: {
+        drawingPlayerId: "p1",
+        cardId: "market_crash",
+        trigger: "round_start",
+      },
+      handshakeAgreements: [
+        {
+          id: "handshake-1",
+          gameId: "game-1",
+          partyA: "p1",
+          partyB: "p2",
+          summary: "private",
+          status: "proposed",
+          proposedBy: "p1",
+          createdAt: 1,
+          signedAt: null,
+          brokenAt: null,
+          brokenBy: null,
+        },
+      ],
+      negotiationThreads: [
+        {
+          id: "private-thread",
+          gameId: "game-1",
+          createdBy: "p1",
+          partyIds: ["p1", "p2"],
+          status: "open",
+          startedRound: 1,
+          expiresAfterRound: 4,
+          visibility: "private",
+          messages: [],
+        },
+        {
+          id: "open-thread",
+          gameId: "game-1",
+          createdBy: "p1",
+          partyIds: ["p1", "p2"],
+          status: "open",
+          startedRound: 1,
+          expiresAfterRound: 4,
+          visibility: "open",
+          messages: [],
+        },
+      ],
+    } as never);
+
+    expect("pendingInsiderPeek" in broadcastState).toBe(false);
+    expect("handshakeAgreements" in broadcastState).toBe(false);
+    expect(
+      broadcastState.negotiationThreads?.map((thread) => thread.id),
+    ).toEqual(["open-thread"]);
+  });
+
   it("redacts dark-pool ownership changes from the broadcast state", () => {
     const state = {
       players: [

--- a/tests/unit/gameStateView.test.ts
+++ b/tests/unit/gameStateView.test.ts
@@ -71,6 +71,35 @@ describe("toClientGameState negotiation visibility", () => {
       "thread-private",
     ]);
   });
+
+  it("hides private threads from spectators", () => {
+    const state = baseState();
+    state.negotiationThreads = [
+      {
+        id: "thread-open",
+        createdBy: "p1",
+        partyIds: ["p1", "p2"],
+        status: "open",
+        startedRound: 1,
+        expiresAfterRound: 4,
+        visibility: "open",
+      },
+      {
+        id: "thread-private",
+        createdBy: "p1",
+        partyIds: ["p1", "p2"],
+        status: "open",
+        startedRound: 1,
+        expiresAfterRound: 4,
+        visibility: "private",
+      },
+    ];
+
+    const client = toClientGameState(state, "spectator", "spectator-1");
+    expect(client.negotiationThreads?.map((entry) => entry.id)).toEqual([
+      "thread-open",
+    ]);
+  });
 });
 
 describe("toClientGameState handshake visibility", () => {

--- a/tests/unit/gameUi.test.ts
+++ b/tests/unit/gameUi.test.ts
@@ -1,6 +1,6 @@
 import type { GameState } from "@oligopoly/validation";
 import { describe, expect, it } from "vitest";
-import { mergeRedactedGameSnapshot } from "../../packages/web/src/lib/gameUi";
+import { mergeAuctionClientView } from "../../packages/web/src/lib/gameUi";
 
 function auctionState(
   pendingAuction: NonNullable<GameState["pendingAuction"]>,
@@ -13,7 +13,7 @@ function auctionState(
   };
 }
 
-describe("mergeRedactedGameSnapshot", () => {
+describe("mergeAuctionClientView", () => {
   it("preserves mySubmission when broadcast snapshots omit it", () => {
     const previous = auctionState({
       tilePosition: 3,
@@ -37,7 +37,7 @@ describe("mergeRedactedGameSnapshot", () => {
       submissionCount: 2,
     });
 
-    const merged = mergeRedactedGameSnapshot(previous, incoming);
+    const merged = mergeAuctionClientView(previous, incoming);
     expect(merged.pendingAuction?.mySubmission).toBe(90);
     expect(merged.pendingAuction?.submissionCount).toBe(2);
   });
@@ -65,7 +65,7 @@ describe("mergeRedactedGameSnapshot", () => {
       submissionCount: 0,
     });
 
-    const merged = mergeRedactedGameSnapshot(previous, incoming);
+    const merged = mergeAuctionClientView(previous, incoming);
     expect(merged.pendingAuction?.mySubmission).toBeUndefined();
   });
 
@@ -92,7 +92,7 @@ describe("mergeRedactedGameSnapshot", () => {
       submissionCount: 2,
     });
 
-    expect(mergeRedactedGameSnapshot(previous, incoming)).toEqual(incoming);
+    expect(mergeAuctionClientView(previous, incoming)).toEqual(incoming);
   });
 
   it("does not preserve mySubmission for live auctions", () => {
@@ -118,68 +118,6 @@ describe("mergeRedactedGameSnapshot", () => {
       submissionCount: 2,
     });
 
-    expect(mergeRedactedGameSnapshot(previous, incoming)).toEqual(incoming);
-  });
-  it("preserves viewer-private fields when public realtime updates omit them", () => {
-    const previous: GameState = {
-      gameId: "game-1",
-      round: 1,
-      phase: "waiting_for_insider_peek",
-      myAffinityCardId: "ai_pioneer",
-      pendingInsiderPeek: {
-        cardId: "market_crash",
-        drawingPlayerId: "p1",
-        trigger: "round_start",
-      },
-      handshakeAgreements: [
-        {
-          id: "handshake-1",
-          partyA: "p1",
-          partyB: "p2",
-          summary: "private",
-          status: "pending",
-          createdRound: 1,
-        },
-      ],
-      negotiationThreads: [
-        {
-          id: "thread-1",
-          createdBy: "p1",
-          partyIds: ["p1", "p2"],
-          status: "open",
-          startedRound: 1,
-          expiresAfterRound: 4,
-          visibility: "private",
-        },
-      ],
-    };
-
-    const incoming: GameState = {
-      gameId: "game-1",
-      round: 1,
-      phase: "waiting_for_insider_peek",
-      negotiationThreads: [
-        {
-          id: "open-thread",
-          createdBy: "p2",
-          partyIds: ["p2", "p3"],
-          status: "open",
-          startedRound: 1,
-          expiresAfterRound: 4,
-          visibility: "open",
-        },
-      ],
-    };
-
-    const merged = mergeRedactedGameSnapshot(previous, incoming);
-    expect(merged.myAffinityCardId).toBe("ai_pioneer");
-    expect(merged.pendingInsiderPeek?.cardId).toBe("market_crash");
-    expect(merged.handshakeAgreements?.map((entry) => entry.id)).toEqual([
-      "handshake-1",
-    ]);
-    expect(merged.negotiationThreads?.map((entry) => entry.id)).toEqual([
-      "open-thread",
-      "thread-1",
-    ]);
+    expect(mergeAuctionClientView(previous, incoming)).toEqual(incoming);
   });
 });

--- a/tests/unit/gameUi.test.ts
+++ b/tests/unit/gameUi.test.ts
@@ -1,6 +1,6 @@
 import type { GameState } from "@oligopoly/validation";
 import { describe, expect, it } from "vitest";
-import { mergeAuctionClientView } from "../../packages/web/src/lib/gameUi";
+import { mergeRedactedGameSnapshot } from "../../packages/web/src/lib/gameUi";
 
 function auctionState(
   pendingAuction: NonNullable<GameState["pendingAuction"]>,
@@ -13,7 +13,7 @@ function auctionState(
   };
 }
 
-describe("mergeAuctionClientView", () => {
+describe("mergeRedactedGameSnapshot", () => {
   it("preserves mySubmission when broadcast snapshots omit it", () => {
     const previous = auctionState({
       tilePosition: 3,
@@ -37,7 +37,7 @@ describe("mergeAuctionClientView", () => {
       submissionCount: 2,
     });
 
-    const merged = mergeAuctionClientView(previous, incoming);
+    const merged = mergeRedactedGameSnapshot(previous, incoming);
     expect(merged.pendingAuction?.mySubmission).toBe(90);
     expect(merged.pendingAuction?.submissionCount).toBe(2);
   });
@@ -65,7 +65,7 @@ describe("mergeAuctionClientView", () => {
       submissionCount: 0,
     });
 
-    const merged = mergeAuctionClientView(previous, incoming);
+    const merged = mergeRedactedGameSnapshot(previous, incoming);
     expect(merged.pendingAuction?.mySubmission).toBeUndefined();
   });
 
@@ -92,7 +92,7 @@ describe("mergeAuctionClientView", () => {
       submissionCount: 2,
     });
 
-    expect(mergeAuctionClientView(previous, incoming)).toEqual(incoming);
+    expect(mergeRedactedGameSnapshot(previous, incoming)).toEqual(incoming);
   });
 
   it("does not preserve mySubmission for live auctions", () => {
@@ -118,7 +118,7 @@ describe("mergeAuctionClientView", () => {
       submissionCount: 2,
     });
 
-    expect(mergeAuctionClientView(previous, incoming)).toEqual(incoming);
+    expect(mergeRedactedGameSnapshot(previous, incoming)).toEqual(incoming);
   });
   it("preserves viewer-private fields when public realtime updates omit them", () => {
     const previous: GameState = {
@@ -171,7 +171,7 @@ describe("mergeAuctionClientView", () => {
       ],
     };
 
-    const merged = mergeAuctionClientView(previous, incoming);
+    const merged = mergeRedactedGameSnapshot(previous, incoming);
     expect(merged.myAffinityCardId).toBe("ai_pioneer");
     expect(merged.pendingInsiderPeek?.cardId).toBe("market_crash");
     expect(merged.handshakeAgreements?.map((entry) => entry.id)).toEqual([

--- a/tests/unit/gameUi.test.ts
+++ b/tests/unit/gameUi.test.ts
@@ -158,6 +158,17 @@ describe("mergeAuctionClientView", () => {
       gameId: "game-1",
       round: 1,
       phase: "waiting_for_insider_peek",
+      negotiationThreads: [
+        {
+          id: "open-thread",
+          createdBy: "p2",
+          partyIds: ["p2", "p3"],
+          status: "open",
+          startedRound: 1,
+          expiresAfterRound: 4,
+          visibility: "open",
+        },
+      ],
     };
 
     const merged = mergeAuctionClientView(previous, incoming);
@@ -167,6 +178,7 @@ describe("mergeAuctionClientView", () => {
       "handshake-1",
     ]);
     expect(merged.negotiationThreads?.map((entry) => entry.id)).toEqual([
+      "open-thread",
       "thread-1",
     ]);
   });

--- a/tests/unit/gameUi.test.ts
+++ b/tests/unit/gameUi.test.ts
@@ -120,4 +120,54 @@ describe("mergeAuctionClientView", () => {
 
     expect(mergeAuctionClientView(previous, incoming)).toEqual(incoming);
   });
+  it("preserves viewer-private fields when public realtime updates omit them", () => {
+    const previous: GameState = {
+      gameId: "game-1",
+      round: 1,
+      phase: "waiting_for_insider_peek",
+      myAffinityCardId: "ai_pioneer",
+      pendingInsiderPeek: {
+        cardId: "market_crash",
+        drawingPlayerId: "p1",
+        trigger: "round_start",
+      },
+      handshakeAgreements: [
+        {
+          id: "handshake-1",
+          partyA: "p1",
+          partyB: "p2",
+          summary: "private",
+          status: "pending",
+          createdRound: 1,
+        },
+      ],
+      negotiationThreads: [
+        {
+          id: "thread-1",
+          createdBy: "p1",
+          partyIds: ["p1", "p2"],
+          status: "open",
+          startedRound: 1,
+          expiresAfterRound: 4,
+          visibility: "private",
+        },
+      ],
+    };
+
+    const incoming: GameState = {
+      gameId: "game-1",
+      round: 1,
+      phase: "waiting_for_insider_peek",
+    };
+
+    const merged = mergeAuctionClientView(previous, incoming);
+    expect(merged.myAffinityCardId).toBe("ai_pioneer");
+    expect(merged.pendingInsiderPeek?.cardId).toBe("market_crash");
+    expect(merged.handshakeAgreements?.map((entry) => entry.id)).toEqual([
+      "handshake-1",
+    ]);
+    expect(merged.negotiationThreads?.map((entry) => entry.id)).toEqual([
+      "thread-1",
+    ]);
+  });
 });

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -88,6 +88,21 @@ describe("AI and realtime schemas", () => {
     expect(result.success).toBe(true);
   });
 
+  it("rejects duplicate lobby AI slot IDs", () => {
+    const result = CreateLobbyInputSchema.safeParse({
+      name: "Duplicate AI",
+      maxPlayers: 3,
+      isPrivate: false,
+      optionalRuleIds: [],
+      aiSlots: [
+        { id: "ai-1", name: "Bot 1", personality: "opportunist" },
+        { id: "ai-1", name: "Bot 2", personality: "loyalist" },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("validates AI personalities", () => {
     expect(AiPersonalitySchema.safeParse("loyalist").success).toBe(true);
     expect(AiPersonalitySchema.safeParse("chaotic").success).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Makes the local two-player lobby flow playable end to end: public lobby create/join, ready checks, game start, and first game actions.
- Adds lobby realtime restoration with fallback-only polling, explicit visibility selection, stale-token clearing, and authenticated game/lobby WebSocket token handling through shared auth middleware.
- Hardens realtime privacy boundaries, player-scoped game WebSocket snapshots, schema-safe action/log payloads, local-only authenticated AI stepping, unique AI slot validation, public lobby seat counts, and D1-backed single-use 24h invites.
- Documents local AI setup and the browser WebSocket token transport exception/log-scrub requirement.

## PR comment resolution log
- Collapsed selected-lobby state writes behind a single commit path and moved join policy into a tested helper.
- Removed broad auto-selection behavior; only a single waiting lobby is auto-selected.
- Changed lobby polling to a WebSocket fallback rather than a parallel always-on transport.
- Extracted shared realtime channel logic for lobby/game sockets.
- Restored viewer-scoped game WebSocket snapshots and removed HTTP refetch-on-every-realtime-update.
- Kept the client merge helper auction-focused and preserved dark-pool realtime redaction without stripping player-private fields.
- Batched public lobby player loading and hardened private lobby WebSocket authorization.
- Made invite tokens D1-backed, single-use, 24h, and consumed after join preconditions pass.
- Added WebSocket token construction/auth coverage and middleware coverage.

## Walkthrough
[two_player_lobby_gameplay_demo.mp4](https://cursor.com/agents/bc-0d8e4cc9-aa26-4794-b1b6-3c3ae9cfd83c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftwo_player_lobby_gameplay_demo.mp4)
[Game after two-player action](https://cursor.com/agents/bc-0d8e4cc9-aa26-4794-b1b6-3c3ae9cfd83c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftwo_player_game_after_action.png)

## Validation
- `pnpm run ci:local`
- `pnpm exec vitest run --project unit tests/unit/gameUi.test.ts tests/unit/gamePersistence.test.ts tests/unit/gameStateView.test.ts tests/unit/validation.test.ts`
- `pnpm exec vitest run --project integration tests/integration/games.test.ts tests/integration/lobbies.test.ts tests/integration/game-actions.test.ts tests/integration/middleware.test.ts`
- `pnpm run --filter @oligopoly/web test -- LobbiesPage.test.tsx games.test.ts lobbies.test.ts`
- CDP browser harness against two separate Chrome profiles: public lobby create/join, both ready, start game, draw market event, roll dice.
- `/thermo-nuclear-code-quality-review`: final git-aware subagent returned `NO_FEEDBACK`.
- `/review-and-ship`: final subagent returned `NO_FEEDBACK`.
- `/loop-on-ci`: `gh pr checks --watch --fail-fast` reports attached checks passing.

## Docs
- Used `oligopoly_technical_plan.md` Backend Runtime and Route Contracts / AI player protocol / Auth consistency rule.
- Used `oligopoly_game_rules.md` Lobby, Solo vs AI, AI Players, invite, and Turn Timeout & AI Takeover sections.
- Updated `oligopoly_dev_guide.md` with local AI player setup instructions.
- Updated `oligopoly_technical_plan.md` for local authenticated AI step and browser WebSocket token transport.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d8e4cc9-aa26-4794-b1b6-3c3ae9cfd83c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8e4cc9-aa26-4794-b1b6-3c3ae9cfd83c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

