### PR TITLE
Fix CORS for 127.0.0.1 and alternate local Vite ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ OPENROUTER_APP_TITLE="Oligopoly Online"
 OPENROUTER_TIMEOUT_MS=8000
 
 ALLOWED_ORIGINS=http://localhost:5173
+# Loopback browser origins (127.0.0.1, alternate Vite ports) are also accepted
+# automatically in local dev; this list is for explicit production/staging hosts.
 CSP_REPORT_URI=
 
 VITE_API_URL=http://localhost:8787

--- a/NON_UI_ISSUES_AND_IDEAS.md
+++ b/NON_UI_ISSUES_AND_IDEAS.md
@@ -26,13 +26,6 @@ current UI-only change set.
 - Add a deterministic two-player local smoke script that creates two dev-login
   users, creates a lobby, joins player two, marks both players ready, starts the
   game, and verifies both game views can fetch state.
-- Align local CORS defaults for alternate Vite ports. A test frontend on
-  `127.0.0.1:5176` with a Worker on `8788` could render but dev-login failed
-  because the request origin was not accepted by the Worker.
-- Fix local browser auth for `127.0.0.1` Vite origins. During this audit,
-  direct bearer-auth API calls to Worker `8789` returned valid game summary,
-  state, and log data, but the browser route from `127.0.0.1:5191` repeatedly
-  fell back to unauthorized game-state/log requests after CORS preflights.
 - Add a browser smoke test for the two-player first-game path with isolated
   browser contexts, not shared local storage.
 - Add telemetry for first-game dropoff: login started, lobby created, invite

--- a/oligopoly_technical_plan.md
+++ b/oligopoly_technical_plan.md
@@ -134,7 +134,7 @@ Framework conventions:
 
 Global middleware order:
 
-1. CORS allowlist middleware
+1. CORS allowlist middleware — honors `ALLOWED_ORIGINS` and also accepts any loopback browser origin (`http(s)://localhost|127.0.0.1|::1` on any port) so local Vite dev servers work without listing every port/host combination.
 2. Rate limit middleware
 3. Ban cache middleware
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,7 +11,11 @@ export {
   UpdateUserSettingsInputSchema,
   VisibilitySettingSchema,
 } from "@oligopoly/validation";
-export { isLoopbackHostname, isLoopbackUrl } from "./net.js";
+export {
+  isLoopbackHostname,
+  isLoopbackOrigin,
+  isLoopbackUrl,
+} from "./net.js";
 export { serializeProfileForAudience } from "./profile/serializeProfileForAudience.js";
 export type {
   AchievementUnlock,

--- a/packages/shared/src/net.ts
+++ b/packages/shared/src/net.ts
@@ -24,3 +24,21 @@ export function isLoopbackUrl(url: string): boolean {
     return false;
   }
 }
+
+/**
+ * True when a browser `Origin` header value points at a loopback dev server
+ * (`http(s)://localhost|127.0.0.1|::1` with any port). Used by the worker CORS
+ * middleware so local Vite ports and `127.0.0.1` hosts work without listing
+ * every combination in `ALLOWED_ORIGINS`.
+ */
+export function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return false;
+    }
+    return isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -3,6 +3,7 @@ import {
   AFFINITY_CARDS,
   DIAGONAL_TILES,
   DISRUPTION_DECK,
+  isLoopbackOrigin,
   MARKET_EVENT_DECK,
   OPTIONAL_MARKET_EVENT_CARDS_REGISTRY,
   OPTIONAL_RULES_REGISTRY,
@@ -52,10 +53,16 @@ app.use(
   "*",
   cors({
     origin: (origin, c) => {
-      const allowed = c.env?.ALLOWED_ORIGINS?.split(",") ?? [
-        "http://localhost:5173",
-      ];
-      return allowed.includes(origin) ? origin : "";
+      const allowed = c.env?.ALLOWED_ORIGINS?.split(",")
+        .map((entry: string) => entry.trim())
+        .filter(Boolean) ?? ["http://localhost:5173"];
+      if (!origin) {
+        return "";
+      }
+      if (allowed.includes(origin) || isLoopbackOrigin(origin)) {
+        return origin;
+      }
+      return "";
     },
   }),
 );

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -53,9 +53,11 @@ app.use(
   "*",
   cors({
     origin: (origin, c) => {
-      const allowed = c.env?.ALLOWED_ORIGINS?.split(",")
+      const allowed = (
+        c.env?.ALLOWED_ORIGINS?.split(",") ?? ["http://localhost:5173"]
+      )
         .map((entry: string) => entry.trim())
-        .filter(Boolean) ?? ["http://localhost:5173"];
+        .filter(Boolean);
       if (!origin) {
         return "";
       }

--- a/tests/integration/middleware.test.ts
+++ b/tests/integration/middleware.test.ts
@@ -27,6 +27,50 @@ const createRequestWithEnv = (
   );
 };
 
+describe("cors", () => {
+  it("allows configured origins", async () => {
+    const res = await createRequestWithEnv("/api/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:5173",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:5173",
+    );
+  });
+
+  it("allows loopback origins not listed in ALLOWED_ORIGINS", async () => {
+    const res = await createRequestWithEnv("/api/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://127.0.0.1:5191",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://127.0.0.1:5191",
+    );
+  });
+
+  it("rejects deployed origins", async () => {
+    const res = await createRequestWithEnv("/api/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://oligopoly.online",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+});
+
 describe("rateLimitMiddleware", () => {
   it("returns 429 when auth IP key is flagged", async () => {
     const res = await createRequestWithEnv("/api/auth/login", {

--- a/tests/integration/middleware.test.ts
+++ b/tests/integration/middleware.test.ts
@@ -10,9 +10,10 @@ const createRequestWithEnv = (
     headers?: HeadersInit;
     kvGet?: KvGet;
     db?: D1Database;
+    allowedOrigins?: string;
   } = {},
 ) => {
-  const { method, headers, kvGet, db } = options;
+  const { method, headers, kvGet, db, allowedOrigins } = options;
   return app.request(
     path,
     {
@@ -20,7 +21,9 @@ const createRequestWithEnv = (
       headers,
     },
     {
-      ALLOWED_ORIGINS: "http://localhost:5173",
+      ...(allowedOrigins === undefined
+        ? {}
+        : { ALLOWED_ORIGINS: allowedOrigins }),
       DB: db,
       KV: kvGet ? ({ get: kvGet } as KVNamespace) : undefined,
     },
@@ -29,6 +32,22 @@ const createRequestWithEnv = (
 
 describe("cors", () => {
   it("allows configured origins", async () => {
+    const res = await createRequestWithEnv("/api/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:5173",
+        "Access-Control-Request-Method": "GET",
+      },
+      allowedOrigins: "http://localhost:5173",
+    });
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:5173",
+    );
+  });
+
+  it("falls back to localhost:5173 when ALLOWED_ORIGINS is unset", async () => {
     const res = await createRequestWithEnv("/api/health", {
       method: "OPTIONS",
       headers: {
@@ -50,6 +69,7 @@ describe("cors", () => {
         Origin: "http://127.0.0.1:5191",
         "Access-Control-Request-Method": "GET",
       },
+      allowedOrigins: "http://localhost:5173",
     });
 
     expect(res.status).toBe(204);
@@ -65,6 +85,7 @@ describe("cors", () => {
         Origin: "https://oligopoly.online",
         "Access-Control-Request-Method": "GET",
       },
+      allowedOrigins: "http://localhost:5173",
     });
 
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();

--- a/tests/unit/net.test.ts
+++ b/tests/unit/net.test.ts
@@ -1,4 +1,8 @@
-import { isLoopbackHostname, isLoopbackUrl } from "@oligopoly/shared";
+import {
+  isLoopbackHostname,
+  isLoopbackOrigin,
+  isLoopbackUrl,
+} from "@oligopoly/shared";
 import { describe, expect, it } from "vitest";
 
 describe("isLoopbackHostname", () => {
@@ -26,5 +30,19 @@ describe("isLoopbackUrl", () => {
   it("rejects deployed and malformed URLs", () => {
     expect(isLoopbackUrl("https://oligopoly.online/api/x")).toBe(false);
     expect(isLoopbackUrl("not a url")).toBe(false);
+  });
+});
+
+describe("isLoopbackOrigin", () => {
+  it("accepts loopback browser origins on any port", () => {
+    expect(isLoopbackOrigin("http://localhost:5173")).toBe(true);
+    expect(isLoopbackOrigin("http://127.0.0.1:5191")).toBe(true);
+    expect(isLoopbackOrigin("http://[::1]:5176")).toBe(true);
+  });
+
+  it("rejects deployed and non-http(s) origins", () => {
+    expect(isLoopbackOrigin("https://oligopoly.online")).toBe(false);
+    expect(isLoopbackOrigin("null")).toBe(false);
+    expect(isLoopbackOrigin("not an origin")).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Local browser auth and API calls failed when the web client was opened at `http://127.0.0.1:<port>` (or any Vite port other than `5173`). CORS only honored explicit `ALLOWED_ORIGINS` entries (defaulting to `http://localhost:5173`), so preflight requests from `127.0.0.1` origins were rejected even though dev-login and other loopback-gated endpoints already accepted those hosts.

## Fix

- Add `isLoopbackOrigin()` in `@oligopoly/shared` to detect browser `Origin` headers for loopback hosts (`localhost`, `127.0.0.1`, `::1`) on any port.
- Update worker CORS middleware to accept configured origins **or** any loopback browser origin.
- Add unit and integration regression tests.
- Document the behavior in `oligopoly_technical_plan.md` and `.env.example`.

## Verification

- `pnpm run ci:local` passes (557 unit + 176 integration + 74 web tests).
- Manual preflight check: `http://127.0.0.1:5191` now receives `Access-Control-Allow-Origin`.

## Planning docs

- **Informed by:** `oligopoly_technical_plan.md` middleware/CORS section.
- **Validated against:** local dev workflow in `oligopoly_dev_guide.md` (loopback dev-login gating).
- **Updated:** `oligopoly_technical_plan.md`, `.env.example`, `NON_UI_ISSUES_AND_IDEAS.md` (removed resolved CORS items).
- **No changes needed:** `oligopoly_game_rules.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c9f4c6a-3423-45aa-bfa1-4632150a92b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c9f4c6a-3423-45aa-bfa1-4632150a92b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

