### PR TITLE
Address set-modal ThermoREVIEW findings

### DIFF
--- a/packages/web/src/components/BoardCell.test.tsx
+++ b/packages/web/src/components/BoardCell.test.tsx
@@ -2,82 +2,14 @@ import type { GameState } from "@oligopoly/validation";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { BoardCell } from "./BoardCell";
-
-function baseState(overrides: Partial<GameState> = {}): GameState {
-  return {
-    gameId: "g",
-    round: 1,
-    phase: "waiting_for_roll",
-    currentPlayerIndex: 0,
-    turnOrder: ["me"],
-    freeMarketPool: 0,
-    pendingBuyTilePosition: null,
-    lastDiceRoll: null,
-    winnerId: null,
-    eliminatedPlayerIds: [],
-    myAffinityCardId: null,
-    players: [
-      {
-        playerId: "me",
-        displayName: "Ada",
-        position: 0,
-        capital: 500,
-        ownedTilePositions: [],
-        mortgagedTilePositions: [],
-        developmentTokens: {},
-        trustworthiness: 7,
-        actionPointsRemaining: 2,
-        inRegulation: false,
-        doublesCount: 0,
-        isOnDiagonal: false,
-      },
-    ],
-    tiles: [
-      {
-        position: 1,
-        ownerId: null,
-        mortgaged: false,
-        developmentTokens: 0,
-      },
-      {
-        position: 3,
-        ownerId: null,
-        mortgaged: false,
-        developmentTokens: 0,
-      },
-    ],
-    ...overrides,
-  };
-}
-
-const tileDetails = new Map([
-  [
-    "1",
-    {
-      position: 1,
-      name: "Alpha Asset",
-      type: "sector_tile" as const,
-      sectorId: "energy",
-      cost: 100,
-      baseRent: 10,
-    },
-  ],
-  [
-    "3",
-    {
-      position: 3,
-      name: "Beta Asset",
-      type: "sector_tile" as const,
-      sectorId: "energy",
-      cost: 120,
-      baseRent: 12,
-    },
-  ],
-]);
+import {
+  setNavigationGameState,
+  setNavigationTileDetails,
+} from "./setNavigationTestFixtures";
 
 describe("BoardCell set browsing", () => {
   it("updates dialog title and details when selecting another set member, then restores opener focus on close", () => {
-    const state = baseState();
+    const state = setNavigationGameState();
     const tilesByPosition = new Map(
       (state.tiles ?? []).map((tile) => [String(tile.position), tile]),
     );
@@ -97,7 +29,7 @@ describe("BoardCell set browsing", () => {
         occupants={[]}
         actorId={null}
         tileNames={tileNames}
-        tileDetails={tileDetails}
+        tileDetails={setNavigationTileDetails}
         myPlayerId="me"
         tileState={tilesByPosition.get("1")}
         tilesByPosition={tilesByPosition}

--- a/packages/web/src/components/BoardCell.test.tsx
+++ b/packages/web/src/components/BoardCell.test.tsx
@@ -1,11 +1,11 @@
 import type { GameState } from "@oligopoly/validation";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { BoardCell } from "./BoardCell";
 import {
   setNavigationGameState,
   setNavigationTileDetails,
-} from "./setNavigationTestFixtures";
+} from "../test/fixtures/setNavigationTestFixtures";
+import { BoardCell } from "./BoardCell";
 
 describe("BoardCell set browsing", () => {
   it("updates dialog title and details when selecting another set member, then restores opener focus on close", () => {

--- a/packages/web/src/components/BoardCell.tsx
+++ b/packages/web/src/components/BoardCell.tsx
@@ -1,11 +1,12 @@
 import type { GameState } from "@oligopoly/validation";
 import type { CSSProperties } from "react";
-import { useCallback, useState } from "react";
+import { useTileSetDialogNavigation } from "../hooks/useTileSetDialogNavigation";
 import { type BoardTileDetails, tileLabel } from "../lib/boardDisplay";
 import { compactOccupantLabel, occupantLabels } from "../lib/boardOccupants";
 import {
   boardTileDisplayName,
   developmentTokenIndexes,
+  resolveViewedTile,
   sectorClass,
   tileStatusLabel,
   tileTypeLabel,
@@ -68,20 +69,20 @@ export function BoardCell({
   const label = tileLabel(position, tileNames);
   const displayName = boardTileDisplayName(position, label);
   const details = tileDetails.get(String(position));
-  const [viewedPosition, setViewedPosition] = useState(position);
-  const viewedKey = String(viewedPosition);
-  const effectivePosition = tileDetails.has(viewedKey)
-    ? viewedPosition
-    : position;
-  const viewedDetails = tileDetails.get(String(effectivePosition));
-  const viewedTileState = tilesByPosition.get(String(effectivePosition));
-  const viewedOwnerId = viewedTileState?.ownerId ?? null;
-  const viewedOccupants =
-    occupantsByPosition.get(String(effectivePosition)) ?? [];
-  const viewedLabel = tileLabel(effectivePosition, tileNames);
-  const handleOpenChange = useCallback(() => {
-    setViewedPosition(position);
-  }, [position]);
+  const {
+    viewedPosition,
+    viewAnnouncement,
+    onDialogOpenChange,
+    onSelectSetMember,
+  } = useTileSetDialogNavigation(position);
+  const viewed = resolveViewedTile({
+    openerPosition: position,
+    viewedPosition,
+    tileDetails,
+    tilesByPosition,
+    occupantsByPosition,
+    tileNames,
+  });
   const mortgaged = tileState?.mortgaged ?? false;
   const developmentTokens = tileState?.developmentTokens ?? 0;
   const statusLabel = tileStatusLabel({
@@ -92,9 +93,9 @@ export function BoardCell({
 
   return (
     <InfoDialog
-      title={viewedLabel}
+      title={viewed.label}
       triggerLabel={`Open details for ${label}`}
-      onOpenChange={handleOpenChange}
+      onOpenChange={onDialogOpenChange}
       triggerClassName={[
         "boardGridCell",
         `boardGridCell-${placement.edge}`,
@@ -160,17 +161,18 @@ export function BoardCell({
       }
     >
       <BoardTileDetailsContent
-        details={viewedDetails}
-        occupants={viewedOccupants}
+        details={viewed.details}
+        occupants={viewed.occupants}
         occupantsByPosition={occupantsByPosition}
-        ownerId={viewedOwnerId}
-        position={effectivePosition}
+        ownerId={viewed.ownerId}
+        position={viewed.position}
         state={state}
         tileDetails={tileDetails}
-        tileState={viewedTileState}
+        tileState={viewed.tileState}
         tilesByPosition={tilesByPosition}
         myPlayerId={myPlayerId}
-        onSelectSetMember={setViewedPosition}
+        viewAnnouncement={viewAnnouncement}
+        onSelectSetMember={onSelectSetMember}
       />
     </InfoDialog>
   );

--- a/packages/web/src/components/BoardSetMemberItem.tsx
+++ b/packages/web/src/components/BoardSetMemberItem.tsx
@@ -1,0 +1,46 @@
+import type { TileSetMember } from "../lib/boardTileDetails";
+
+export function BoardSetMemberItem({
+  member,
+  onSelect,
+}: {
+  member: TileSetMember;
+  onSelect: (position: number | string, label: string) => void;
+}) {
+  const className = [
+    "boardSetItem",
+    member.selected ? "boardSetItemSelected" : "",
+    member.mortgaged ? "boardSetItemMortgaged" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <li>
+      <button
+        type="button"
+        className={className}
+        aria-pressed={member.selected}
+        onClick={(event) => {
+          if (member.selected) return;
+          event.currentTarget.focus();
+          onSelect(member.position, member.label);
+        }}
+      >
+        <span className="boardSetPosition">{member.position}</span>
+        <span className="boardSetMain">
+          <strong>{member.label}</strong>
+          <span>
+            Owned by {member.ownerLabel}
+            {member.occupantLabel
+              ? ` | Players here: ${member.occupantLabel}`
+              : ""}
+          </span>
+        </span>
+        <span className="boardSetStatus">
+          {member.selected ? "Selected" : member.statusLabel}
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/packages/web/src/components/BoardTileDetailsContent.test.tsx
+++ b/packages/web/src/components/BoardTileDetailsContent.test.tsx
@@ -2,81 +2,17 @@ import type { GameState } from "@oligopoly/validation";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { BoardTileDetailsContent } from "./BoardTileDetailsContent";
+import {
+  setNavigationGameState,
+  setNavigationTileDetails,
+} from "./setNavigationTestFixtures";
 
-function baseState(overrides: Partial<GameState> = {}): GameState {
-  return {
-    gameId: "g",
-    round: 1,
-    phase: "waiting_for_roll",
-    currentPlayerIndex: 0,
-    turnOrder: ["me"],
-    freeMarketPool: 0,
-    pendingBuyTilePosition: null,
-    lastDiceRoll: null,
-    winnerId: null,
-    eliminatedPlayerIds: [],
-    myAffinityCardId: null,
-    players: [
-      {
-        playerId: "me",
-        displayName: "Ada",
-        position: 0,
-        capital: 500,
-        ownedTilePositions: [],
-        mortgagedTilePositions: [],
-        developmentTokens: {},
-        trustworthiness: 7,
-        actionPointsRemaining: 2,
-        inRegulation: false,
-        doublesCount: 0,
-        isOnDiagonal: false,
-      },
-    ],
-    tiles: [
-      {
-        position: 1,
-        ownerId: null,
-        mortgaged: false,
-        developmentTokens: 0,
-      },
-      {
-        position: 3,
-        ownerId: null,
-        mortgaged: false,
-        developmentTokens: 0,
-      },
-    ],
-    ...overrides,
-  };
-}
-
-const tileDetails = new Map([
-  [
-    "1",
-    {
-      position: 1,
-      name: "Alpha Asset",
-      type: "sector_tile",
-      sectorId: "energy",
-      cost: 100,
-      baseRent: 10,
-    },
-  ],
-  [
-    "3",
-    {
-      position: 3,
-      name: "Beta Asset",
-      type: "sector_tile",
-      sectorId: "energy",
-      cost: 120,
-      baseRent: 12,
-    },
-  ],
-]);
-
-function renderContent(position: number, onSelectSetMember = vi.fn()) {
-  const state = baseState();
+function renderContent(
+  position: number,
+  onSelectSetMember = vi.fn(),
+  viewAnnouncement = "",
+) {
+  const state = setNavigationGameState();
   const tilesByPosition = new Map(
     (state.tiles ?? []).map((tile) => [String(tile.position), tile]),
   );
@@ -88,16 +24,17 @@ function renderContent(position: number, onSelectSetMember = vi.fn()) {
     onSelectSetMember,
     ...render(
       <BoardTileDetailsContent
-        details={tileDetails.get(String(position))}
+        details={setNavigationTileDetails.get(String(position))}
         occupants={[]}
         occupantsByPosition={occupantsByPosition}
         ownerId={null}
         position={position}
         state={state}
-        tileDetails={tileDetails}
+        tileDetails={setNavigationTileDetails}
         tileState={tilesByPosition.get(String(position))}
         tilesByPosition={tilesByPosition}
         myPlayerId="me"
+        viewAnnouncement={viewAnnouncement}
         onSelectSetMember={onSelectSetMember}
       />,
     ),
@@ -114,15 +51,18 @@ describe("BoardTileDetailsContent set navigation", () => {
     expect(other).toHaveAttribute("aria-pressed", "false");
 
     fireEvent.click(other);
-    expect(onSelectSetMember).toHaveBeenCalledWith(3);
-    expect(screen.getByRole("status")).toHaveTextContent(/viewing beta asset/i);
+    expect(onSelectSetMember).toHaveBeenCalledWith(3, "Beta Asset");
   });
 
-  it("does not re-select or re-announce the already selected member", () => {
+  it("does not re-select the already selected member", () => {
     const { onSelectSetMember } = renderContent(1);
     const selected = screen.getByRole("button", { name: /alpha asset/i });
     fireEvent.click(selected);
     expect(onSelectSetMember).not.toHaveBeenCalled();
-    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+
+  it("surfaces the view announcement live region", () => {
+    renderContent(1, vi.fn(), "Viewing Beta Asset");
+    expect(screen.getByRole("status")).toHaveTextContent(/viewing beta asset/i);
   });
 });

--- a/packages/web/src/components/BoardTileDetailsContent.test.tsx
+++ b/packages/web/src/components/BoardTileDetailsContent.test.tsx
@@ -1,11 +1,11 @@
 import type { GameState } from "@oligopoly/validation";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { BoardTileDetailsContent } from "./BoardTileDetailsContent";
 import {
   setNavigationGameState,
   setNavigationTileDetails,
-} from "./setNavigationTestFixtures";
+} from "../test/fixtures/setNavigationTestFixtures";
+import { BoardTileDetailsContent } from "./BoardTileDetailsContent";
 
 function renderContent(
   position: number,

--- a/packages/web/src/components/BoardTileDetailsContent.tsx
+++ b/packages/web/src/components/BoardTileDetailsContent.tsx
@@ -122,7 +122,7 @@ export function BoardTileDetailsContent({
 
   return (
     <div className="tileDetailsSurface">
-      <div className="visuallyHidden" role="status">
+      <div className="visuallyHidden" role="status" aria-live="polite">
         {viewAnnouncement}
       </div>
       <section className="tileDetailsHero">

--- a/packages/web/src/components/BoardTileDetailsContent.tsx
+++ b/packages/web/src/components/BoardTileDetailsContent.tsx
@@ -1,5 +1,4 @@
 import type { GameState } from "@oligopoly/validation";
-import { useState } from "react";
 import type { BoardTileDetails } from "../lib/boardDisplay";
 import { occupantLabels } from "../lib/boardOccupants";
 import {
@@ -14,6 +13,7 @@ import {
 } from "../lib/boardTileDetails";
 import { formatCurrencyAmount, playerDisplayName } from "../lib/gameDisplay";
 import { getTileEconomics } from "../lib/tileEconomics";
+import { BoardSetMemberItem } from "./BoardSetMemberItem";
 import { TileEconomicsExplainContent } from "./TileEconomicsExplainContent";
 
 type BoardTileDetailsContentProps = {
@@ -27,7 +27,8 @@ type BoardTileDetailsContentProps = {
   tileState: NonNullable<GameState["tiles"]>[number] | undefined;
   tilesByPosition: Map<string, NonNullable<GameState["tiles"]>[number]>;
   myPlayerId: string | null;
-  onSelectSetMember?: (position: number | string) => void;
+  viewAnnouncement: string;
+  onSelectSetMember: (position: number | string, label: string) => void;
 };
 
 export function BoardTileDetailsContent({
@@ -41,9 +42,9 @@ export function BoardTileDetailsContent({
   tileState,
   tilesByPosition,
   myPlayerId,
+  viewAnnouncement,
   onSelectSetMember,
 }: BoardTileDetailsContentProps) {
-  const [viewAnnouncement, setViewAnnouncement] = useState("");
   const currencySettings = state.settings;
   const developmentTokens = tileState?.developmentTokens ?? 0;
   const mortgaged = tileState?.mortgaged ?? false;
@@ -121,7 +122,7 @@ export function BoardTileDetailsContent({
 
   return (
     <div className="tileDetailsSurface">
-      <div className="visuallyHidden" role="status" aria-live="polite">
+      <div className="visuallyHidden" role="status">
         {viewAnnouncement}
       </div>
       <section className="tileDetailsHero">
@@ -206,54 +207,13 @@ export function BoardTileDetailsContent({
               <strong>{setInfo.title}</strong>
             </div>
             <ul className="boardSetList">
-              {setInfo.members.map((member) => {
-                const className = [
-                  "boardSetItem",
-                  member.selected ? "boardSetItemSelected" : "",
-                  member.mortgaged ? "boardSetItemMortgaged" : "",
-                ]
-                  .filter(Boolean)
-                  .join(" ");
-                const body = (
-                  <>
-                    <span className="boardSetPosition">{member.position}</span>
-                    <span className="boardSetMain">
-                      <strong>{member.label}</strong>
-                      <span>
-                        Owned by {member.ownerLabel}
-                        {member.occupantLabel
-                          ? ` | Players here: ${member.occupantLabel}`
-                          : ""}
-                      </span>
-                    </span>
-                    <span className="boardSetStatus">
-                      {member.selected ? "Selected" : member.statusLabel}
-                    </span>
-                  </>
-                );
-
-                return (
-                  <li key={String(member.position)}>
-                    {onSelectSetMember ? (
-                      <button
-                        type="button"
-                        className={className}
-                        aria-pressed={member.selected}
-                        onClick={(event) => {
-                          if (member.selected) return;
-                          event.currentTarget.focus();
-                          setViewAnnouncement(`Viewing ${member.label}`);
-                          onSelectSetMember(member.position);
-                        }}
-                      >
-                        {body}
-                      </button>
-                    ) : (
-                      <div className={className}>{body}</div>
-                    )}
-                  </li>
-                );
-              })}
+              {setInfo.members.map((member) => (
+                <BoardSetMemberItem
+                  key={String(member.position)}
+                  member={member}
+                  onSelect={onSelectSetMember}
+                />
+              ))}
             </ul>
           </div>
         </section>

--- a/packages/web/src/components/InfoDialog.test.tsx
+++ b/packages/web/src/components/InfoDialog.test.tsx
@@ -37,7 +37,7 @@ describe("InfoDialog", () => {
     expect(trigger).toHaveFocus();
   });
 
-  it("notifies onOpenChange when opened and closed", () => {
+  it("notifies onOpenChange only on open and close transitions", () => {
     const onOpenChange = vi.fn();
     render(
       <InfoDialog
@@ -49,15 +49,14 @@ describe("InfoDialog", () => {
       </InfoDialog>,
     );
 
-    expect(onOpenChange).toHaveBeenCalledTimes(1);
-    expect(onOpenChange).toHaveBeenNthCalledWith(1, false);
+    expect(onOpenChange).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: /explain tile/i }));
-    expect(onOpenChange).toHaveBeenCalledWith(true);
-    const callsAfterOpen = onOpenChange.mock.calls.length;
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
 
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(onOpenChange).toHaveBeenCalledTimes(callsAfterOpen + 1);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
     expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/packages/web/src/components/InfoDialog.tsx
+++ b/packages/web/src/components/InfoDialog.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 type InfoDialogProps = {
@@ -8,6 +8,7 @@ type InfoDialogProps = {
   triggerClassName?: string;
   triggerStyle?: CSSProperties;
   triggerContent?: ReactNode;
+  /** Called only on open/close transitions — never on mount. */
   onOpenChange?: (open: boolean) => void;
   children: ReactNode;
 };
@@ -28,6 +29,16 @@ export function InfoDialog({
   const dialogRef = useRef<HTMLElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
   const wasOpenRef = useRef(false);
+  const openRef = useRef(false);
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+
+  const updateOpen = useCallback((next: boolean) => {
+    if (openRef.current === next) return;
+    openRef.current = next;
+    setOpen(next);
+    onOpenChangeRef.current?.(next);
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -55,7 +66,7 @@ export function InfoDialog({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        setOpen(false);
+        updateOpen(false);
         return;
       }
       if (event.key !== "Tab") {
@@ -105,7 +116,7 @@ export function InfoDialog({
         htmlElement.inert = previousInert;
       }
     };
-  }, [open]);
+  }, [open, updateOpen]);
 
   useEffect(() => {
     if (wasOpenRef.current && !open) {
@@ -113,10 +124,6 @@ export function InfoDialog({
     }
     wasOpenRef.current = open;
   }, [open]);
-
-  useEffect(() => {
-    onOpenChange?.(open);
-  }, [open, onOpenChange]);
 
   return (
     <>
@@ -126,7 +133,7 @@ export function InfoDialog({
         className={triggerClassName}
         style={triggerStyle}
         aria-label={triggerLabel}
-        onClick={() => setOpen(true)}
+        onClick={() => updateOpen(true)}
       >
         {triggerContent}
       </button>
@@ -138,7 +145,7 @@ export function InfoDialog({
               className="modalBackdropDismiss"
               tabIndex={-1}
               aria-label={`Close ${title}`}
-              onMouseDown={() => setOpen(false)}
+              onMouseDown={() => updateOpen(false)}
             />
             <section
               ref={dialogRef}
@@ -154,7 +161,7 @@ export function InfoDialog({
                   type="button"
                   className="button buttonSecondary"
                   aria-label={`Close ${title}`}
-                  onClick={() => setOpen(false)}
+                  onClick={() => updateOpen(false)}
                 >
                   Close
                 </button>

--- a/packages/web/src/components/setNavigationTestFixtures.ts
+++ b/packages/web/src/components/setNavigationTestFixtures.ts
@@ -1,0 +1,76 @@
+import type { GameState } from "@oligopoly/validation";
+import type { BoardTileDetails } from "../lib/boardDisplay";
+
+export function setNavigationGameState(
+  overrides: Partial<GameState> = {},
+): GameState {
+  return {
+    gameId: "g",
+    round: 1,
+    phase: "waiting_for_roll",
+    currentPlayerIndex: 0,
+    turnOrder: ["me"],
+    freeMarketPool: 0,
+    pendingBuyTilePosition: null,
+    lastDiceRoll: null,
+    winnerId: null,
+    eliminatedPlayerIds: [],
+    myAffinityCardId: null,
+    players: [
+      {
+        playerId: "me",
+        displayName: "Ada",
+        position: 0,
+        capital: 500,
+        ownedTilePositions: [],
+        mortgagedTilePositions: [],
+        developmentTokens: {},
+        trustworthiness: 7,
+        actionPointsRemaining: 2,
+        inRegulation: false,
+        doublesCount: 0,
+        isOnDiagonal: false,
+      },
+    ],
+    tiles: [
+      {
+        position: 1,
+        ownerId: null,
+        mortgaged: false,
+        developmentTokens: 0,
+      },
+      {
+        position: 3,
+        ownerId: null,
+        mortgaged: false,
+        developmentTokens: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export const setNavigationTileDetails = new Map<string, BoardTileDetails>([
+  [
+    "1",
+    {
+      position: 1,
+      name: "Alpha Asset",
+      type: "sector_tile",
+      sectorId: "energy",
+      cost: 100,
+      baseRent: 10,
+    },
+  ],
+  [
+    "3",
+    {
+      position: 3,
+      name: "Beta Asset",
+      type: "sector_tile",
+      sectorId: "energy",
+      cost: 120,
+      baseRent: 12,
+    },
+  ],
+]);

--- a/packages/web/src/hooks/useTileSetDialogNavigation.ts
+++ b/packages/web/src/hooks/useTileSetDialogNavigation.ts
@@ -2,8 +2,9 @@ import { useCallback, useState } from "react";
 
 /**
  * Owns set-browsing state for a board-tile details dialog: which tile is
- * viewed, live-region copy, reset on open/close, and member selection.
+ * viewed, live-region copy, reset on close, and member selection.
  * Relies on a stable opener `position` for the mounted cell.
+ * Selected-member no-ops are handled in `BoardSetMemberItem` (UI layer).
  */
 export function useTileSetDialogNavigation(openerPosition: number | string) {
   const [viewedPosition, setViewedPosition] = useState(openerPosition);
@@ -12,9 +13,9 @@ export function useTileSetDialogNavigation(openerPosition: number | string) {
   const onDialogOpenChange = useCallback(
     (open: boolean) => {
       // Real open/close transitions only (InfoDialog never notifies on mount).
-      // Reset on both so reopen always starts on the opener cell's tile.
-      setViewedPosition(openerPosition);
+      // Close resets; next open starts from opener via this + initial useState.
       if (!open) {
+        setViewedPosition(openerPosition);
         setViewAnnouncement("");
       }
     },
@@ -23,11 +24,10 @@ export function useTileSetDialogNavigation(openerPosition: number | string) {
 
   const onSelectSetMember = useCallback(
     (nextPosition: number | string, label: string) => {
-      if (String(nextPosition) === String(viewedPosition)) return;
       setViewAnnouncement(`Viewing ${label}`);
       setViewedPosition(nextPosition);
     },
-    [viewedPosition],
+    [],
   );
 
   return {

--- a/packages/web/src/hooks/useTileSetDialogNavigation.ts
+++ b/packages/web/src/hooks/useTileSetDialogNavigation.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Owns set-browsing state for a board-tile details dialog: which tile is
+ * viewed, live-region copy, reset on open/close, and member selection.
+ * Relies on a stable opener `position` for the mounted cell.
+ */
+export function useTileSetDialogNavigation(openerPosition: number | string) {
+  const [viewedPosition, setViewedPosition] = useState(openerPosition);
+  const [viewAnnouncement, setViewAnnouncement] = useState("");
+
+  const onDialogOpenChange = useCallback(
+    (open: boolean) => {
+      // Real open/close transitions only (InfoDialog never notifies on mount).
+      // Reset on both so reopen always starts on the opener cell's tile.
+      setViewedPosition(openerPosition);
+      if (!open) {
+        setViewAnnouncement("");
+      }
+    },
+    [openerPosition],
+  );
+
+  const onSelectSetMember = useCallback(
+    (nextPosition: number | string, label: string) => {
+      if (String(nextPosition) === String(viewedPosition)) return;
+      setViewAnnouncement(`Viewing ${label}`);
+      setViewedPosition(nextPosition);
+    },
+    [viewedPosition],
+  );
+
+  return {
+    viewedPosition,
+    viewAnnouncement,
+    onDialogOpenChange,
+    onSelectSetMember,
+  };
+}

--- a/packages/web/src/lib/boardTileDetails.ts
+++ b/packages/web/src/lib/boardTileDetails.ts
@@ -6,7 +6,7 @@ import {
   MAX_DEVELOPMENT_TOKENS,
 } from "@oligopoly/shared";
 import type { GameState } from "@oligopoly/validation";
-import type { BoardTileDetails } from "./boardDisplay";
+import { type BoardTileDetails, tileLabel } from "./boardDisplay";
 import { occupantLabels } from "./boardOccupants";
 import { playerDisplayName } from "./gameDisplay";
 
@@ -257,7 +257,7 @@ export function currentRentRowId({
   return null;
 }
 
-type TileSetMember = {
+export type TileSetMember = {
   developmentTokens: number;
   label: string;
   mortgaged: boolean;
@@ -267,6 +267,43 @@ type TileSetMember = {
   selected: boolean;
   statusLabel: string;
 };
+
+export function resolveViewedTile({
+  openerPosition,
+  viewedPosition,
+  tileDetails,
+  tilesByPosition,
+  occupantsByPosition,
+  tileNames,
+}: {
+  openerPosition: number | string;
+  viewedPosition: number | string;
+  tileDetails: Map<string, BoardTileDetails>;
+  tilesByPosition: Map<string, NonNullable<GameState["tiles"]>[number]>;
+  occupantsByPosition: Map<string, NonNullable<GameState["players"]>>;
+  tileNames: Map<string, string>;
+}): {
+  position: number | string;
+  details: BoardTileDetails | undefined;
+  tileState: NonNullable<GameState["tiles"]>[number] | undefined;
+  ownerId: string | null;
+  occupants: NonNullable<GameState["players"]>;
+  label: string;
+} {
+  const position = tileDetails.has(String(viewedPosition))
+    ? viewedPosition
+    : openerPosition;
+  const key = String(position);
+  const tileState = tilesByPosition.get(key);
+  return {
+    position,
+    details: tileDetails.get(key),
+    tileState,
+    ownerId: tileState?.ownerId ?? null,
+    occupants: occupantsByPosition.get(key) ?? [],
+    label: tileLabel(position, tileNames),
+  };
+}
 
 export type TileSetInfo = {
   members: TileSetMember[];

--- a/packages/web/src/test/fixtures/setNavigationTestFixtures.ts
+++ b/packages/web/src/test/fixtures/setNavigationTestFixtures.ts
@@ -1,5 +1,5 @@
 import type { GameState } from "@oligopoly/validation";
-import type { BoardTileDetails } from "../lib/boardDisplay";
+import type { BoardTileDetails } from "../../lib/boardDisplay";
 
 export function setNavigationGameState(
   overrides: Partial<GameState> = {},


### PR DESCRIPTION
## Summary
- Follow-up to #74 (merged before review fixes landed): fire `InfoDialog.onOpenChange` only on real open/close transitions (no mount-time `false` for every board cell)
- Extract `resolveViewedTile` and `useTileSetDialogNavigation` so browse state, reset, and live-region copy live in one place
- Always render set members as buttons via `BoardSetMemberItem` (remove optional button/div fork); share set-navigation test fixtures

## Test plan
- [ ] `pnpm --filter @oligopoly/web test` (pre-push `ci:local`)
- [ ] Open a set tile dialog, browse members, Escape — confirm no mount reset side effects and title/body still swap
- [ ] Confirm review threads from #74 are covered by this change


Made with [Cursor](https://cursor.com)